### PR TITLE
Fix time format in docs

### DIFF
--- a/docs/using/subsetting.rst
+++ b/docs/using/subsetting.rst
@@ -40,9 +40,9 @@ while ``end="2020"`` is equivalent to ``end="2020-12-31"``.
 
 Note also how the ``frequency`` of the dataset will change how the
 ``end`` option is interpreted: - ``end="2020"`` with a ``frequency`` of
-one hour is equivalent to ``end="2020-12-31 23:00"`` - ``end="2020"``
+one hour is equivalent to ``end="2020-12-31 23:00:00"`` - ``end="2020"``
 with a ``frequency`` of 6 hours is equivalent to ``end="2020-12-31
-18:00"``
+18:00:00"``
 
 .. _frequency:
 


### PR DESCRIPTION
According to https://github.com/ecmwf/anemoi-datasets/blame/3d2ed9079c3e1cfda7a45cf3d0b00a2f9c05d9cc/src/anemoi/datasets/data/misc.py#L137 the time must always be specified as `hh:mm:ss`.

As an alternative to fixing the docs, I would see quite a few advantages in following the ISO 8601 standard and in using the python package `isodate` to parse dates.