### PR TITLE
Help the user debugging stores.py

### DIFF
--- a/src/anemoi/datasets/data/stores.py
+++ b/src/anemoi/datasets/data/stores.py
@@ -111,6 +111,9 @@ def open_zarr(path, dont_fail=False, cache=None):
 
         if DEBUG_ZARR_LOADING:
             if isinstance(store, str):
+                import os
+                if not os.path.isdir(store):
+                    raise NotImplementedError("DEBUG_ZARR_LOADING is only implemented for DirectoryStore. Please disable it for other backends.")
                 store = zarr.storage.DirectoryStore(store)
             store = DebugStore(store)
 


### PR DESCRIPTION
The code crashed with `DEBUG_ZARR_LOADING=1` and it took me a while to figure out what was going on until I realized, that the debugging assumes `DirectoryStore` while other formats are supported by `zarr.convenience.open` in principle.