### PR TITLE
Normalize missing dates before removing time zone

### DIFF
--- a/src/anemoi/datasets/dates/groups.py
+++ b/src/anemoi/datasets/dates/groups.py
@@ -9,7 +9,7 @@
 import itertools
 
 from anemoi.datasets.dates import Dates
-from anemoi.datasets.dates import no_time_zone
+from anemoi.datasets.dates import normalize_date
 
 
 class Groups:
@@ -67,7 +67,7 @@ class Groups:
 
 class Filter:
     def __init__(self, missing):
-        self.missing = [no_time_zone(m) for m in missing]
+        self.missing = [normalize_date(m) for m in missing]
 
     def __call__(self, dates):
         return [d for d in dates if d not in self.missing]


### PR DESCRIPTION
Missing dates read from a yaml config are datetime objects, the function `no_time_zone` fails when it is called with a datetime object. The change aims at transforming missing dates to isoformat before applying `no_time_zone` as it is the case with other dates.