### PR TITLE
Change the merge strategy for Changelog to Union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Keep it human-readable, your future self will thank you!
 ### Added
 - CI workflow to update the changelog on release
 - adds the reusable cd pypi workflow
+- merge strategy for changelog in .gitattributes #25
 
 ### Changed
  -  update CI to reusable workflows for PRs and releases


### PR DESCRIPTION
Suggested merge strategy to avoid changelog merge conflicts: https://github.com/olivierlacan/keep-a-changelog/discussions/587

Should help us with most trivial changes, we'll have to see if it works trivially on the Release updates.