### PR TITLE
bugfix: rename dates to group_of_dates

### DIFF
--- a/src/anemoi/datasets/create/input.py
+++ b/src/anemoi/datasets/create/input.py
@@ -798,7 +798,7 @@ class StepFunctionResult(StepResult):
             raise
 
     def _trace_datasource(self, *args, **kwargs):
-        return f"{self.action.name}({shorten(self.dates)})"
+        return f"{self.action.name}({shorten(self.group_of_dates)})"
 
 
 class FilterStepResult(StepResult):


### PR DESCRIPTION
It seems that with commit 53ab37d4422e4e658c9d5196438d338b74ae7fe2, one renaming of `dates` to `group_of_dates` in the `StepFunctionResult` class was missed: 
https://github.com/ecmwf/anemoi-datasets/blob/647e2165df62e25036714476344feefb0aba6477/src/anemoi/datasets/create/input.py#L780-L801

This PR fixes that. 

