### PR TITLE
Bugfix/52 error subclass metadata specific must be implemented in derived class cropping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Keep it human-readable, your future self will thank you!
 - Add missing dependency for documentation building
 - Fix failing test due to previous merge
 - Bug fix when creating dataset from zarr
+- Bug fix with area selection in cutout operation
 
 ### Removed
 

--- a/src/anemoi/datasets/data/masked.py
+++ b/src/anemoi/datasets/data/masked.py
@@ -112,5 +112,5 @@ class Cropping(Masked):
     def tree(self):
         return Node(self, [self.forward.tree()], area=self.area)
 
-    def metadata_specific(self, **kwargs):
-        return super().metadata_specific(area=self.area, **kwargs)
+    def subclass_metadata_specific(self):
+        return dict(area=self.area)


### PR DESCRIPTION
This PR implements a bug fix for Issue #52 .