### PR TITLE
feature: add accumulation KWARGS for CERRA

### DIFF
--- a/src/anemoi/datasets/create/functions/sources/accumulations.py
+++ b/src/anemoi/datasets/create/functions/sources/accumulations.py
@@ -375,6 +375,7 @@ def accumulations(context, dates, **request):
         ("od", "elda"): dict(base_times=(6, 18)),
         ("ea", "oper"): dict(data_accumulation_period=1, base_times=(6, 18)),
         ("ea", "enda"): dict(data_accumulation_period=3, base_times=(6, 18)),
+        ("rr", "oper"): dict(data_accumulation_period=3, base_times=(0, 3, 6, 9, 12, 15, 18, 21)),
     }
 
     kwargs = KWARGS.get((class_, stream), {})


### PR DESCRIPTION
This PR adds the appropriate `data_accumultation_period` and `base_times`  kwargs when calculating accumulations from mars CERRA `('rr', 'oper')` data.