### PR TITLE
Fix/remove upstream deps from ci

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -1,9 +1,3 @@
-dependencies: |
-  ecmwf/ecbuild
-  MathisRosenhauer/libaec@master
-  ecmwf/eccodes
-  ecmwf/eckit
-  ecmwf/odc
 dependency_branch: develop
 parallelism_factor: 8
 self_build: false # Only for python packages

--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -2,6 +2,8 @@ build:
   python: '3.10'
   modules:
     - ninja
+  python_dependencies:
+    - ecmwf/anemoi-utils@develop
   parallel: 64
   pytest_cmd: |
     python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml

--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -2,17 +2,6 @@ build:
   python: '3.10'
   modules:
     - ninja
-  dependencies:
-    - ecmwf/ecbuild@develop
-    - ecmwf/eccodes@develop
-    - ecmwf/eckit@develop
-    - ecmwf/odc@develop
-  python_dependencies:
-    - ecmwf/anemoi-utils@develop
-    - ecmwf/earthkit-data@develop
-    - ecmwf/earthkit-meteo@develop
-    - ecmwf/earthkit-geo@develop
   parallel: 64
-
   pytest_cmd: |
     python -m pytest -vv -m 'not notebook and not no_cache_init' --cov=. --cov-report=xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     name: downstream-ci
     if: ${{ !contains(github.repository, 'private') && (!github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci') }}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@fix/remove_anemoi_datasets_from_upstream
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
     with:
       anemoi-datasets: ecmwf/anemoi-datasets@${{ github.event.pull_request.head.sha || github.sha }}
       codecov_upload: true
@@ -48,7 +48,7 @@ jobs:
   downstream-ci-hpc:
     name: downstream-ci-hpc
     if: ${{ !contains(github.repository, 'private') && (!github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci') }}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@fix/remove_anemoi_datasets_from_upstream
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
     with:
       anemoi-datasets: ecmwf/anemoi-datasets@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     name: downstream-ci
     if: ${{ !contains(github.repository, 'private') && (!github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci') }}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@fix/remove_anemoi_datasets_from_upstream
     with:
       anemoi-datasets: ecmwf/anemoi-datasets@${{ github.event.pull_request.head.sha || github.sha }}
       codecov_upload: true
@@ -48,7 +48,7 @@ jobs:
   downstream-ci-hpc:
     name: downstream-ci-hpc
     if: ${{ !contains(github.repository, 'private') && (!github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci') }}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@fix/remove_anemoi_datasets_from_upstream
     with:
       anemoi-datasets: ecmwf/anemoi-datasets@${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Keep it human-readable, your future self will thank you!
 
 ## [Unreleased](https://github.com/ecmwf/anemoi-datasets/compare/0.5.7...HEAD)
 
+### Changed
+
+- Remove upstream dependencies from downstream-ci workflow (temporary) (#83)
+
 ## [0.5.7](https://github.com/ecmwf/anemoi-datasets/compare/0.5.6...0.5.7) - 2024-10-09
 
 ## [Allow for unknown CF coordinates](https://github.com/ecmwf/anemoi-datasets/compare/0.5.5...0.5.6) - 2024-10-04


### PR DESCRIPTION
Test whether we can remove upstream dependencies from the downstream ci workflows to temporarily cut the dependency tree between anemoi and other ECMWF packages.