### PR TITLE
feat: Allow noncontinuous ranges of time to be given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Keep it human-readable, your future self will thank you!
 ### Changed
 - make test optional when adls is not installed Pull request #110
 
+### Added
+- Allow non continuous time ranges [#118](https://github.com/ecmwf/anemoi-datasets/pull/118)
+
 ## [0.5.8](https://github.com/ecmwf/anemoi-datasets/compare/0.5.7...0.5.8) - 2024-10-26
 
 ### Changed

--- a/docs/using/code/dates_.py
+++ b/docs/using/code/dates_.py
@@ -1,0 +1,1 @@
+open_dataset(dataset, dates=[(1980, 1990, 12)])

--- a/docs/using/subsetting.rst
+++ b/docs/using/subsetting.rst
@@ -64,3 +64,20 @@ dates.
 
 .. literalinclude:: code/frequency2_.py
    :language: python
+
+.. _dates:
+
+*******
+ dates
+*******
+
+You can specify non continuous dates by passing a list of dates:
+
+.. literalinclude:: code/dates_.py
+   :language: python
+
+Each date must be either a 2 or 3 element tuple. The first element is
+the start date, the second element is the end date and the third element
+is an optional override of the frequency.
+
+Each element will follow the typing and rules listed above.

--- a/src/anemoi/datasets/data/dataset.py
+++ b/src/anemoi/datasets/data/dataset.py
@@ -94,6 +94,9 @@ class Dataset:
             return ds._subset(**kwargs).mutate()
 
         if "start" in kwargs or "end" in kwargs:
+            if "ranges" in kwargs:
+                raise ValueError("Cannot use both `ranges` and `start`/`end` together.")
+
             start = kwargs.pop("start", None)
             end = kwargs.pop("end", None)
 
@@ -101,6 +104,18 @@ class Dataset:
 
             return (
                 Subset(self, self._dates_to_indices(start, end), dict(start=start, end=end))._subset(**kwargs).mutate()
+            )
+
+        if "ranges" in kwargs:
+            ranges = kwargs.pop("ranges")
+            from .subset import Subset
+
+            return (
+                Subset(
+                    self, [r for rang in ranges for r in self._dates_to_indices(rang[0], rang[1])], dict(ranges=ranges)
+                )
+                ._subset(**kwargs)
+                .mutate()
             )
 
         if "frequency" in kwargs:

--- a/src/anemoi/datasets/data/dataset.py
+++ b/src/anemoi/datasets/data/dataset.py
@@ -107,6 +107,9 @@ class Dataset:
             )
 
         if "dates" in kwargs:
+            if "interpolate_frequency" in kwargs:
+                raise ValueError("Cannot use both `dates` and `interpolate_frequency`")
+
             dates: list[tuple] = kwargs.pop("dates")
 
             from .subset import Subset
@@ -114,7 +117,7 @@ class Dataset:
             def get_indices(start: str | int, end: str | int, frequency: int | None = None) -> list[int]:
                 date_indices = self._dates_to_indices(start, end)
 
-                # frequency = frequency or kwargs.get("frequency", None)
+                frequency = frequency or kwargs.get("frequency", None)
                 if frequency is not None:
                     return list(
                         map(
@@ -122,7 +125,6 @@ class Dataset:
                             Subset(self, date_indices, dict(start=start, end=end))._frequency_to_indices(frequency),
                         )
                     )
-                    return list(set(date_indices).intersection(self._frequency_to_indices(frequency)))
                 return date_indices
 
             return (

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -746,6 +746,58 @@ def test_dates_5():
 
 
 @mockup_open_zarr
+def test_frequency_3():
+    test = DatasetTester(
+        "test-2021-2023-1h-o96-abcd", dates=[("2022-06", "2022-07"), ("2022-09", "2022-10", 24)], frequency=12
+    )
+    expected_dates = []
+    expected_dates.extend(
+        [datetime.datetime(2022, 6, 1) + datetime.timedelta(hours=i * 12) for i in range((30 + 31) * 2)]
+    )
+    expected_dates.extend([datetime.datetime(2022, 9, 1) + datetime.timedelta(hours=i * 24) for i in range((30 + 31))])
+
+    test.run(
+        expected_class=Subset,
+        expected_length=((30 + 31) * 2 + (30 + 31)),
+        start_date=datetime.datetime(2022, 6, 1),
+        time_increment=datetime.timedelta(hours=12),
+        expected_shape=((30 + 31) * 2 + (30 + 31), 4, 1, VALUES),
+        expected_variables="abcd",
+        expected_name_to_index="abcd",
+        date_to_row=lambda date: simple_row(date, "abcd"),
+        statistics_reference_dataset="test-2021-2023-1h-o96-abcd",
+        statistics_reference_variables="abcd",
+        expected_dates=expected_dates,
+    )
+
+
+@mockup_open_zarr
+def test_frequency_4():
+    test = DatasetTester(
+        "test-2021-2023-1h-o96-abcd", dates=[("2022-06", "2022-07", 12), ("2022-09", "2022-10")], frequency=24
+    )
+    expected_dates = []
+    expected_dates.extend(
+        [datetime.datetime(2022, 6, 1) + datetime.timedelta(hours=i * 12) for i in range((30 + 31) * 2)]
+    )
+    expected_dates.extend([datetime.datetime(2022, 9, 1) + datetime.timedelta(hours=i * 24) for i in range((30 + 31))])
+
+    test.run(
+        expected_class=Subset,
+        expected_length=((30 + 31) * 2 + (30 + 31)),
+        start_date=datetime.datetime(2022, 6, 1),
+        time_increment=datetime.timedelta(hours=12),
+        expected_shape=((30 + 31) * 2 + (30 + 31), 4, 1, VALUES),
+        expected_variables="abcd",
+        expected_name_to_index="abcd",
+        date_to_row=lambda date: simple_row(date, "abcd"),
+        statistics_reference_dataset="test-2021-2023-1h-o96-abcd",
+        statistics_reference_variables="abcd",
+        expected_dates=expected_dates,
+    )
+
+
+@mockup_open_zarr
 def test_select_1():
     test = DatasetTester("test-2021-2021-6h-o96-abcd", select=["b", "d"])
     test.run(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -609,8 +609,8 @@ def test_subset_8():
 
 
 @mockup_open_zarr
-def test_ranges_1():
-    test = DatasetTester("test-2021-2023-1h-o96-abcd", ranges=[("2022-06", "2022-08")])
+def test_dates_1():
+    test = DatasetTester("test-2021-2023-1h-o96-abcd", dates=[("2022-06", "2022-08")])
     test.run(
         expected_class=Subset,
         expected_length=(30 + 31 + 31) * 24,
@@ -626,8 +626,25 @@ def test_ranges_1():
 
 
 @mockup_open_zarr
-def test_ranges_2():
-    test = DatasetTester("test-2021-2023-1h-o96-abcd", ranges=[(202206, 202208)])
+def test_dates_frequency_1():
+    test = DatasetTester("test-2021-2023-1h-o96-abcd", dates=[("2022-06", "2022-08", 12)])
+    test.run(
+        expected_class=Subset,
+        expected_length=(30 + 31 + 31) * 2,
+        start_date=datetime.datetime(2022, 6, 1),
+        time_increment=datetime.timedelta(hours=12),
+        expected_shape=((30 + 31 + 31) * 2, 4, 1, VALUES),
+        expected_variables="abcd",
+        expected_name_to_index="abcd",
+        date_to_row=lambda date: simple_row(date, "abcd"),
+        statistics_reference_dataset="test-2021-2023-1h-o96-abcd",
+        statistics_reference_variables="abcd",
+    )
+
+
+@mockup_open_zarr
+def test_dates_2():
+    test = DatasetTester("test-2021-2023-1h-o96-abcd", dates=[(202206, 202208)])
     test.run(
         expected_class=Subset,
         expected_length=(30 + 31 + 31) * 24,
@@ -643,8 +660,8 @@ def test_ranges_2():
 
 
 @mockup_open_zarr
-def test_ranges_3():
-    test = DatasetTester("test-2021-2023-1h-o96-abcd", ranges=[("2022-06", "2022-08"), ("2022-09", "2022-10")])
+def test_dates_3():
+    test = DatasetTester("test-2021-2023-1h-o96-abcd", dates=[("2022-06", "2022-08"), ("2022-09", "2022-10")])
     test.run(
         expected_class=Subset,
         expected_length=(30 + 31 + 31 + 30 + 31) * 24,
@@ -660,8 +677,32 @@ def test_ranges_3():
 
 
 @mockup_open_zarr
-def test_ranges_4():
-    test = DatasetTester("test-2021-2023-1h-o96-abcd", ranges=[("2022-06", "2022-07"), ("2022-09", "2022-10")])
+def test_dates_frequency_2():
+    test = DatasetTester("test-2021-2023-1h-o96-abcd", dates=[("2022-06", "2022-07", 12), ("2022-09", "2022-10", 24)])
+    expected_dates = []
+    expected_dates.extend(
+        [datetime.datetime(2022, 6, 1) + datetime.timedelta(hours=i * 12) for i in range((30 + 31) * 2)]
+    )
+    expected_dates.extend([datetime.datetime(2022, 9, 1) + datetime.timedelta(hours=i * 24) for i in range((30 + 31))])
+
+    test.run(
+        expected_class=Subset,
+        expected_length=((30 + 31) * 2 + (30 + 31)),
+        start_date=datetime.datetime(2022, 6, 1),
+        time_increment=datetime.timedelta(hours=12),
+        expected_shape=((30 + 31) * 2 + (30 + 31), 4, 1, VALUES),
+        expected_variables="abcd",
+        expected_name_to_index="abcd",
+        date_to_row=lambda date: simple_row(date, "abcd"),
+        statistics_reference_dataset="test-2021-2023-1h-o96-abcd",
+        statistics_reference_variables="abcd",
+        expected_dates=expected_dates,
+    )
+
+
+@mockup_open_zarr
+def test_dates_4():
+    test = DatasetTester("test-2021-2023-1h-o96-abcd", dates=[("2022-06", "2022-07"), ("2022-09", "2022-10")])
 
     expected_dates = []
     expected_dates.extend([datetime.datetime(2022, 6, 1) + datetime.timedelta(hours=i) for i in range((30 + 31) * 24)])
@@ -683,8 +724,8 @@ def test_ranges_4():
 
 
 @mockup_open_zarr
-def test_ranges_5():
-    test = DatasetTester("test-2021-2023-1h-o96-abcd", ranges=[("2021", "2021"), ("2023", "2023")], frequency=12)
+def test_dates_5():
+    test = DatasetTester("test-2021-2023-1h-o96-abcd", dates=[("2021", "2021"), ("2023", "2023")], frequency=12)
     expected_dates = []
     expected_dates.extend([datetime.datetime(2021, 1, 1) + datetime.timedelta(hours=i * 12) for i in range(365 * 2)])
     expected_dates.extend([datetime.datetime(2023, 1, 1) + datetime.timedelta(hours=i * 12) for i in range(365 * 2)])


### PR DESCRIPTION
- To be used in `anemoi.training`

Allows for a dataset to consist of seperate slices of time

<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--118.org.readthedocs.build/en/118/

<!-- readthedocs-preview anemoi-datasets end -->