### PR TITLE
Update to documentation on using missing dates

### DIFF
--- a/docs/using/missing.rst
+++ b/docs/using/missing.rst
@@ -3,6 +3,16 @@
 ########################
  Managing missing dates
 ########################
+*********************************************
+ Managing missing dates with anemoi-training
+*********************************************
+
+Anemoi-training has internal handling of missing dates, and will 
+calculate the valid date indices used during training using the 
+``missing`` property. Consequenctly, when training a model with 
+anemoi-training, you should `not` specify a method to deal with 
+missing dates in the dataloader configuration file.
+
 
 **************************************************
  Filling the missing dates with artificial values

--- a/docs/using/missing.rst
+++ b/docs/using/missing.rst
@@ -3,16 +3,16 @@
 ########################
  Managing missing dates
 ########################
+
 *********************************************
  Managing missing dates with anemoi-training
 *********************************************
 
-Anemoi-training has internal handling of missing dates, and will 
-calculate the valid date indices used during training using the 
-``missing`` property. Consequenctly, when training a model with 
-anemoi-training, you should `not` specify a method to deal with 
-missing dates in the dataloader configuration file.
-
+Anemoi-training has internal handling of missing dates, and will
+calculate the valid date indices used during training using the
+``missing`` property. Consequenctly, when training a model with
+anemoi-training, you should `not` specify a method to deal with missing
+dates in the dataloader configuration file.
 
 **************************************************
  Filling the missing dates with artificial values


### PR DESCRIPTION
Anemoi-training has internal handling that deals with missing dates in the dataset https://github.com/ecmwf/anemoi-training/blob/develop/src/anemoi/training/utils/usable_indices.py, and when training on a dataset with missing dates you do not have to specify this in the dataloader config. 
The current documentation on missing dates is confusing because it states that you should specify skip_missing_dates and expected_access which does not work with how missing dates are handled in anemoi-training. I realise that anemoi-datasets can be used for applications outside anemoi-training where the skip_missing_dates functionality can be useful, so I propose adding a short section on how to deal with missing_dates in anemoi-training since this will be the most common use case. 

<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--128.org.readthedocs.build/en/128/

<!-- readthedocs-preview anemoi-datasets end -->