### PR TITLE
fix: Ensure metadata serialization handles numpy.integer properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Keep it human-readable, your future self will thank you!
 
 - Call filters from anemoi-transform
 - make test optional when adls is not installed Pull request #110
+- Bugfix for numpy ints in metadata
 
 
 ## [0.5.8](https://github.com/ecmwf/anemoi-datasets/compare/0.5.7...0.5.8) - 2024-10-26

--- a/src/anemoi/datasets/data/dataset.py
+++ b/src/anemoi/datasets/data/dataset.py
@@ -15,6 +15,7 @@ import pprint
 import warnings
 from functools import cached_property
 
+import numpy as np
 from anemoi.utils.dates import frequency_to_seconds
 from anemoi.utils.dates import frequency_to_string
 from anemoi.utils.dates import frequency_to_timedelta
@@ -41,6 +42,9 @@ def _tidy(v):
 
     if isinstance(v, slice):
         return (v.start, v.stop, v.step)
+
+    if isinstance(v, np.integer):
+        return int(v)
 
     return v
 


### PR DESCRIPTION
This PR fixes a bug where int64 objects in the metadata raised `TypeError: Object of type int64 is not JSON serializable` by converting them to a python-native int.