### PR TITLE
Fix division-by-zero when computing statistics for a single-time dataset

### DIFF
--- a/src/anemoi/datasets/data/dataset.py
+++ b/src/anemoi/datasets/data/dataset.py
@@ -468,7 +468,7 @@ class Dataset:
         sample_count = min(4, len(indices))
         count = len(indices)
 
-        p = slice(0, count, count // (sample_count - 1))
+        p = slice(0, count, count // max(1, sample_count - 1))
         samples = list(range(*p.indices(count)))
 
         samples.append(count - 1)  # Add last


### PR DESCRIPTION
When calculating sample indices, make sure that at least one sample is included.

Example of the problem:

```
$ anemoi-datasets create example.yaml test.zarr
[..]
  File "/home/users/partio/src/anemoi-datasets/src/anemoi/datasets/data/dataset.py", line 471, in _compute_constant_fields_from_a_few_samples
      p = slice(0, count, count // (sample_count - 1))
                        ~~~~~~^^~~~~~~~~~~~~~~~~~~~
ZeroDivisionError: integer division or modulo by zero
```

example.yaml:

```
dates:
  start: 2024-10-12T14:00:00Z
  end: 2024-10-12T14:00:00Z
  frequency: 1h
input:
  join:
  - grib:
      path: example.grib2
      param: [2t]
      levtype: sfc
```