### PR TITLE
Added reorder sort string, which sorts variables alphabetically.

### DIFF
--- a/src/anemoi/datasets/data/dataset.py
+++ b/src/anemoi/datasets/data/dataset.py
@@ -249,13 +249,19 @@ class Dataset:
         return sorted([v for k, v in self.name_to_index.items() if k not in vars])
 
     def _reorder_to_columns(self, vars):
+        if isinstance(vars, str) and vars=="sort":
+            # Sorting the variables alphabetically.
+            # This is cruical for pre-training then transfer learning in combination with
+            # cutout and adjust = 'all'
+            
+            indices = [self.name_to_index[k] for k, v in sorted(self.name_to_index.items(), key=lambda x: x[0])]
+            assert set(indices) == set(range(len(self.name_to_index)))
+            return indices
+        
         if isinstance(vars, (list, tuple)):
             vars = {k: i for i, k in enumerate(vars)}
 
-        indices = []
-
-        for k, v in sorted(vars.items(), key=lambda x: x[1]):
-            indices.append(self.name_to_index[k])
+        indices = [self.name_to_index[k] for k, v in sorted(vars.items(), key=lambda x: x[1])]
 
         # Make sure we don't forget any variables
         assert set(indices) == set(range(len(self.name_to_index)))

--- a/src/anemoi/datasets/data/dataset.py
+++ b/src/anemoi/datasets/data/dataset.py
@@ -249,15 +249,15 @@ class Dataset:
         return sorted([v for k, v in self.name_to_index.items() if k not in vars])
 
     def _reorder_to_columns(self, vars):
-        if isinstance(vars, str) and vars=="sort":
+        if isinstance(vars, str) and vars == "sort":
             # Sorting the variables alphabetically.
             # This is cruical for pre-training then transfer learning in combination with
             # cutout and adjust = 'all'
-            
+
             indices = [self.name_to_index[k] for k, v in sorted(self.name_to_index.items(), key=lambda x: x[0])]
             assert set(indices) == set(range(len(self.name_to_index)))
             return indices
-        
+
         if isinstance(vars, (list, tuple)):
             vars = {k: i for i, k in enumerate(vars)}
 


### PR DESCRIPTION
**Quick summary:**
Added another reordering option reorder="sort" which sorts the variables alphabetically to enable transfer learning for stretched grid.

**Why, and what is the purpose?**

During transfer learning of stretched-grid model, the cutout and the option adjust='all' functionality is used. This will result that the combined dataset (ds1 and ds2) will have their variable list sorted alphabetically. However, then the pretrained model 
needs to follow this type of sorting. This implementation will reorder the variable list to sort them alphabetically, hence enabling transfer learning when use multiple datasets when using reorder='sort'.

I have done some test, and also created some units tests, but unsure on where to put LAM dataset in order to make the testing work. For now I will submit this as a draft PR, if unit test is needed I will also include them.