### PR TITLE
Fix cutout slicing of grid dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ Keep it human-readable, your future self will thank you!
 
 ## [Unreleased](https://github.com/ecmwf/anemoi-datasets/compare/0.5.8...HEAD)
 
+## Changed
+
+- Fix metadata serialization handling of numpy.integer (#140)
+- Fix cutout slicing of grid dimension (#145)
 
 ### Added
 
 - Call filters from anemoi-transform
 - make test optional when adls is not installed Pull request #110
-- Bugfix for numpy ints in metadata
-
 
 ## [0.5.8](https://github.com/ecmwf/anemoi-datasets/compare/0.5.7...0.5.8) - 2024-10-26
 

--- a/src/anemoi/datasets/data/grids.py
+++ b/src/anemoi/datasets/data/grids.py
@@ -289,14 +289,15 @@ class Cutout(GridsBase):
         """
         index, changes = index_to_slices(index, self.shape)
         # Select data from each LAM
-        lam_data = [lam[index] for lam in self.lams]
+        lam_data = [lam[index[:3]] for lam in self.lams]
 
         # First apply spatial indexing on `self.globe` and then apply the mask
         globe_data_sliced = self.globe[index[:3]]
         globe_data = globe_data_sliced[..., self.global_mask]
 
-        # Concatenate LAM data with global data
-        result = np.concatenate(lam_data + [globe_data], axis=self.axis)
+        # Concatenate LAM data with global data, apply the grid slicing
+        result = np.concatenate(lam_data + [globe_data], axis=self.axis)[..., index[3]]
+
         return apply_index_to_slices_changes(result, changes)
 
     def collect_supporting_arrays(self, collected, *path):


### PR DESCRIPTION
This PR fixes a bug with slicing Cutout datasets where slicing the grid dimension didn't work: 

```
cfg = {
    "cutout": [
        {
            "dataset": "metno-meps-archive-det-opendap-2p5km-2020-2023-6h-v1", 
            "thinning": 25
        },
        {
            "dataset": "aifs-od-an-oper-0001-mars-o96-2016-2023-6h-v6"
        }
    ], "adjust": "all"
}

ds = open_dataset(cfg)
sample = ds[1324:1327, :, :, :]
print(sample.shape)
sample = ds[1324:1327, :, :, 0:20000]
print(sample.shape)
```

previously gave

```
(3, 85, 1, 41459)
(3, 85, 1, 41459)
```

now gives

```
(3, 85, 1, 41459)
(3, 85, 1, 20000)
```

@b8raoult @floriankrb @JPXKQX @paulina-t 