### PR TITLE
Allow selection of one or more members in an ensemble dataset

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ datasets <building-introduction>`.
 -  :doc:`using/subsetting`
 -  :doc:`using/combining`
 -  :doc:`using/selecting`
+-  :doc:`using/ensembles`
 -  :doc:`using/grids`
 -  :doc:`using/zip`
 -  :doc:`using/statistics`
@@ -65,6 +66,7 @@ datasets <building-introduction>`.
    using/subsetting
    using/combining
    using/selecting
+   using/ensembles
    using/grids
    using/zip
    using/statistics

--- a/docs/using/code/number1_.py
+++ b/docs/using/code/number1_.py
@@ -1,0 +1,4 @@
+ds = open_dataset(
+    dataset,
+    number=1,
+)

--- a/docs/using/code/number2_.py
+++ b/docs/using/code/number2_.py
@@ -1,0 +1,4 @@
+ds = open_dataset(
+    dataset,
+    number=[1, 3, 5],
+)

--- a/docs/using/ensembles.rst
+++ b/docs/using/ensembles.rst
@@ -1,0 +1,27 @@
+.. _selecting-members:
+
+###################
+ Selecting members
+###################
+
+This section describes how to subset data that are part of an ensemble.
+To combine ensembles, see :ref:`ensembles` in the
+:ref:`combining-datasets` section.
+
+.. _number:
+
+If a dataset is an ensemble, you can select one or more specific members
+using the `number` option. You can also use ``numbers`` (which is an
+alias for ``number``), and ``member`` (or ``members``). The difference
+between the two is that ``number`` is **1-based**, while ``member`` is
+**0-based**.
+
+Select a single element:
+
+.. literalinclude:: code/number1_.py
+   :language: python
+
+... or a list:
+
+.. literalinclude:: code/number2_.py
+   :language: python

--- a/docs/using/selecting.rst
+++ b/docs/using/selecting.rst
@@ -103,15 +103,15 @@ rescale the data.
 If a dataset is an ensemble, you can select one or more specific members
 using the `number` option. You can also use ``numbers`` (which is an
 alias for ``number``), and ``member`` (or ``members``). The difference
-between the two is that ``number`` is *1-based*, while ``member`` is
-*0-based*.
+between the two is that ``number`` is **1-based**, while ``member`` is
+**0-based**.
 
-Select a single member:
+Select a single element:
 
 .. literalinclude:: code/number1_.py
    :language: python
 
-Select a list of members:
+... or a list:
 
 .. literalinclude:: code/number2_.py
    :language: python

--- a/docs/using/selecting.rst
+++ b/docs/using/selecting.rst
@@ -67,6 +67,26 @@ You can also rename variables:
 This will be useful when you join datasets and do not want variables
 from one dataset to override the ones from the other.
 
+********
+ number
+********
+
+If a dataset is an ensemble, you can select one or more specific members
+using the `number` option. You can also use ``numbers`` (which is an
+alias for ``number``), and ``member`` (or ``members``). The difference
+between the two is that ``number`` is **1-based**, while ``member`` is
+**0-based**.
+
+Select a single element:
+
+.. literalinclude:: code/number1_.py
+   :language: python
+
+... or a list:
+
+.. literalinclude:: code/number2_.py
+   :language: python
+
 .. _rescale:
 
 *********
@@ -89,29 +109,9 @@ rescale the data.
 .. warning::
 
    When providing units, the library assumes that the mapping between
-   them is a linear transformation. No check is does to ensure this is
+   them is a linear transformation. No check is done to ensure this is
    the case.
 
 .. _cfunits: https://github.com/NCAS-CMS/cfunits
 
 .. _number:
-
-********
- number
-********
-
-If a dataset is an ensemble, you can select one or more specific members
-using the `number` option. You can also use ``numbers`` (which is an
-alias for ``number``), and ``member`` (or ``members``). The difference
-between the two is that ``number`` is **1-based**, while ``member`` is
-**0-based**.
-
-Select a single element:
-
-.. literalinclude:: code/number1_.py
-   :language: python
-
-... or a list:
-
-.. literalinclude:: code/number2_.py
-   :language: python

--- a/docs/using/selecting.rst
+++ b/docs/using/selecting.rst
@@ -67,6 +67,8 @@ You can also rename variables:
 This will be useful when you join datasets and do not want variables
 from one dataset to override the ones from the other.
 
+.. _rescale:
+
 *********
  rescale
 *********
@@ -91,3 +93,25 @@ rescale the data.
    the case.
 
 .. _cfunits: https://github.com/NCAS-CMS/cfunits
+
+.. _number:
+
+********
+ number
+********
+
+If a dataset is an ensemble, you can select one or more specific members
+using the `number` option. You can also use ``numbers`` (which is an
+alias for ``number``), and ``member`` (or ``members``). The difference
+between the two is that ``number`` is *1-based*, while ``member`` is
+*0-based*.
+
+Select a single member:
+
+.. literalinclude:: code/number1_.py
+   :language: python
+
+Select a list of members:
+
+.. literalinclude:: code/number2_.py
+   :language: python

--- a/src/anemoi/datasets/data/dataset.py
+++ b/src/anemoi/datasets/data/dataset.py
@@ -168,13 +168,15 @@ class Dataset:
             bbox = kwargs.pop("area")
             return Cropping(self, bbox)._subset(**kwargs).mutate()
 
-        if "number" in kwargs or "numbers" in kwargs:
+        if "number" in kwargs or "numbers" or "member" in kwargs or "members" in kwargs:
             from .ensemble import Number
 
-            assert ("number" in kwargs) != ("numbers" in kwargs), "Either 'number' or 'numbers' must be provided"
+            members = {}
+            for key in ["number", "numbers", "member", "members"]:
+                if key in kwargs:
+                    members[key] = kwargs.pop(key)
 
-            numbers = kwargs.pop("number", kwargs.pop("numbers", None))
-            return Number(self, numbers)._subset(**kwargs).mutate()
+            return Number(self, **members)._subset(**kwargs).mutate()
 
         if "set_missing_dates" in kwargs:
             from .missing import MissingDates

--- a/src/anemoi/datasets/data/dataset.py
+++ b/src/anemoi/datasets/data/dataset.py
@@ -168,12 +168,12 @@ class Dataset:
             bbox = kwargs.pop("area")
             return Cropping(self, bbox)._subset(**kwargs).mutate()
 
-        if "number" in kwargs or 'numbers' in kwargs:
+        if "number" in kwargs or "numbers" in kwargs:
             from .ensemble import Number
 
-            assert ('number' in kwargs) != ('numbers' in kwargs), "Either 'number' or 'numbers' must be provided"
+            assert ("number" in kwargs) != ("numbers" in kwargs), "Either 'number' or 'numbers' must be provided"
 
-            numbers = kwargs.pop("number", kwargs.pop("numbers", None   ))
+            numbers = kwargs.pop("number", kwargs.pop("numbers", None))
             return Number(self, numbers)._subset(**kwargs).mutate()
 
         if "set_missing_dates" in kwargs:

--- a/src/anemoi/datasets/data/dataset.py
+++ b/src/anemoi/datasets/data/dataset.py
@@ -168,6 +168,14 @@ class Dataset:
             bbox = kwargs.pop("area")
             return Cropping(self, bbox)._subset(**kwargs).mutate()
 
+        if "number" in kwargs or 'numbers' in kwargs:
+            from .ensemble import Number
+
+            assert ('number' in kwargs) != ('numbers' in kwargs), "Either 'number' or 'numbers' must be provided"
+
+            numbers = kwargs.pop("number", kwargs.pop("numbers", None   ))
+            return Number(self, numbers)._subset(**kwargs).mutate()
+
         if "set_missing_dates" in kwargs:
             from .missing import MissingDates
 

--- a/src/anemoi/datasets/data/ensemble.py
+++ b/src/anemoi/datasets/data/ensemble.py
@@ -9,12 +9,17 @@
 
 
 import logging
+
 import numpy as np
+
 from .debug import Node
-from .forwards import Forwards, GivenAxis
+from .forwards import Forwards
+from .forwards import GivenAxis
+from .indexing import apply_index_to_slices_changes
+from .indexing import index_to_slices
+from .indexing import update_tuple
 from .misc import _auto_adjust
 from .misc import _open
-from .indexing import update_tuple, index_to_slices,apply_index_to_slices_changes
 
 LOG = logging.getLogger(__name__)
 
@@ -30,35 +35,32 @@ class Number(Forwards):
         for n in numbers:
             assert 1 <= n <= forward.shape[2], "Invalid number. `number` is one-based"
 
-        self.mask = np.array([n+1 in numbers for n in range(forward.shape[2])], dtype=bool)
+        self.mask = np.array([n + 1 in numbers for n in range(forward.shape[2])], dtype=bool)
 
     @property
     def shape(self):
         shape, _ = update_tuple(self.forward.shape, 2, len(self.mask))
         return shape
 
-    # @debug_indexing
-    def __getitem__(self, n):
-        if isinstance(n, tuple):
-            return self._get_tuple(n)
-
-        if isinstance(n, int):
-            result = self.forward[n]
+    def __getitem__(self, index):
+        if isinstance(index, int):
+            result = self.forward[index]
             result = result[:, self.mask, :]
             return result
 
-        if isinstance(n, slice):
-            result = self.forward[n]
+        if isinstance(index, slice):
+            result = self.forward[index]
             result = result[:, :, self.mask, :]
             return result
 
         index, changes = index_to_slices(index, self.shape)
         result = self.forward[index]
-        result = result[:,:, self.mask, :]
+        result = result[:, :, self.mask, :]
         return apply_index_to_slices_changes(result, changes)
 
     def tree(self):
         return Node(self, [d.tree() for d in self.datasets])
+
 
 class Ensemble(GivenAxis):
     def tree(self):

--- a/src/anemoi/datasets/data/ensemble.py
+++ b/src/anemoi/datasets/data/ensemble.py
@@ -9,14 +9,56 @@
 
 
 import logging
-
+import numpy as np
 from .debug import Node
-from .forwards import GivenAxis
+from .forwards import Forwards, GivenAxis
 from .misc import _auto_adjust
 from .misc import _open
+from .indexing import update_tuple, index_to_slices,apply_index_to_slices_changes
 
 LOG = logging.getLogger(__name__)
 
+
+class Number(Forwards):
+    def __init__(self, forward, numbers):
+        super().__init__(forward)
+        if not isinstance(numbers, (list, tuple)):
+            numbers = [numbers]
+
+        numbers = [int(n) for n in numbers]
+
+        for n in numbers:
+            assert 1 <= n <= forward.shape[2], "Invalid number. `number` is one-based"
+
+        self.mask = np.array([n+1 in numbers for n in range(forward.shape[2])], dtype=bool)
+
+    @property
+    def shape(self):
+        shape, _ = update_tuple(self.forward.shape, 2, len(self.mask))
+        return shape
+
+    # @debug_indexing
+    def __getitem__(self, n):
+        if isinstance(n, tuple):
+            return self._get_tuple(n)
+
+        if isinstance(n, int):
+            result = self.forward[n]
+            result = result[:, self.mask, :]
+            return result
+
+        if isinstance(n, slice):
+            result = self.forward[n]
+            result = result[:, :, self.mask, :]
+            return result
+
+        index, changes = index_to_slices(index, self.shape)
+        result = self.forward[index]
+        result = result[:,:, self.mask, :]
+        return apply_index_to_slices_changes(result, changes)
+
+    def tree(self):
+        return Node(self, [d.tree() for d in self.datasets])
 
 class Ensemble(GivenAxis):
     def tree(self):

--- a/src/anemoi/datasets/data/merge.py
+++ b/src/anemoi/datasets/data/merge.py
@@ -134,6 +134,9 @@ class Merge(Combined):
     def tree(self):
         return Node(self, [d.tree() for d in self.datasets], allow_gaps_in_dates=self.allow_gaps_in_dates)
 
+    def metadata_specific(self):
+        return {"allow_gaps_in_dates": self.allow_gaps_in_dates}
+
     @debug_indexing
     def __getitem__(self, n):
         if isinstance(n, tuple):


### PR DESCRIPTION
This feature allows the selection of one or more members of an ensemble dataset:

```Python
open_dataset("path-to-zarr", number=1)
```

and 

```Python
open_dataset("path-to-zarr", number=[1, 3, 5])
```



<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--156.org.readthedocs.build/en/156/

<!-- readthedocs-preview anemoi-datasets end -->