### PR TITLE
feat: support list indices for sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Keep it human-readable, your future self will thank you!
 - Call filters from anemoi-transform
 - Make test optional when adls is not installed Pull request #110
 - Add wz_to_w, orog_to_z, and sum filters (#149)
+- Support list of indices for spatial masking (#162)
 
 ## [0.5.8](https://github.com/ecmwf/anemoi-datasets/compare/0.5.7...0.5.8) - 2024-10-26
 

--- a/src/anemoi/datasets/data/indexing.py
+++ b/src/anemoi/datasets/data/indexing.py
@@ -18,7 +18,7 @@ def _tuple_with_slices(t, shape):
 
     result = tuple(slice(i, i + 1) if isinstance(i, int) else i for i in t)
     changes = tuple(j for (j, i) in enumerate(t) if isinstance(i, int))
-    result = tuple(slice(*s.indices(shape[i])) for (i, s) in enumerate(result))
+    result = tuple(s if isinstance(s, list) else slice(*s.indices(shape[i])) for (i, s) in enumerate(result))
 
     return result, changes
 


### PR DESCRIPTION
This PR addresses that the following command fails when `grid_shard_indices` is a list of indices.

```
x = self.data[100:105, :, :, grid_shard_indices]
```