### PR TITLE
fix: create forcings based on xarray-zarr template

### DIFF
--- a/src/anemoi/datasets/create/input/template.py
+++ b/src/anemoi/datasets/create/input/template.py
@@ -67,7 +67,7 @@ def substitute(context, x):
     if not isinstance(x, str):
         return x
 
-    if re.match(r"^\${[\.\w]+}$", x):
+    if re.match(r"^\${[\.\w\-]+}$", x):
         path = x[2:-1].split(".")
         context.will_need_reference(path)
         return Reference(context, path)


### PR DESCRIPTION
## Description

When creating forcings using a data source template, there is code that looks for a string that's something like ${input.join.0.datasource}. For example, datasource could be "mars", "netcdf", or "xarray-zarr". However, this code fails 
 for data sources like "xarray-zarr" because the string has a "-" in it. I tracked this down to this regular expression: https://github.com/ecmwf/anemoi-datasets/blob/998cc8f2d922f792ac38f0f825228f9dedc15c26/src/anemoi/datasets/create/input/template.py#L70

By explicitly allowing "-" characters (this PR), xarray-zarr data sources can now be used as a template for creating forcings.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

<!-- Link the Issue number this change addresses, ideally in one of the "magic format" such as Closes #XYZ -->

<!-- Alternatively, explain the motivation behind the changes and the context in which they are being made. -->

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

<details><summary>Here's a screenshot of my local tests, showing what was skipped</summary>

![Screenshot 2025-02-14 at 4 06 06 PM](https://github.com/user-attachments/assets/4386a8eb-1cf1-489a-811e-aedc6988bff8)

</details>

### Dependencies

N/A

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

N/A

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

Here is a minimal yaml file that fails currently, but passes with this PR:

```yaml
dates:
  start: 2021-01-01T00:00:00
  end: 2021-01-01T12:00:00
  frequency: 1h

input:
  join:
    - xarray-zarr:
        url: "gs://gcp-public-data-arco-era5/ar/1959-2022-1h-360x181_equiangular_with_poles_conservative.zarr"
        param:
          - 2m_temperature
    - forcings:
        template: ${input.join.0.xarray-zarr}
        param:
          - cos_latitude
```

I think it might be nice to test this, but I think I would need some help figuring out how and where to add such a test.


