### PR TITLE
fix: allow xarrays with single value dimensions

### DIFF
--- a/src/anemoi/datasets/create/functions/sources/xarray/coordinates.py
+++ b/src/anemoi/datasets/create/functions/sources/xarray/coordinates.py
@@ -187,7 +187,7 @@ class Coordinate:
         values = self.variable.values
 
         # Check if dimension is 0D
-        if not isinstance(values,(list, np.ndarray)):
+        if not isinstance(values, (list, np.ndarray)):
             values = [values]
 
         # Assume the array is sorted
@@ -220,7 +220,7 @@ class Coordinate:
         values = self.variable.values
 
         # Check if dimension is 0D
-        if not isinstance(values,(list, np.ndarray)):
+        if not isinstance(values, (list, np.ndarray)):
             values = [values]
 
         # Assume the array is sorted

--- a/src/anemoi/datasets/create/functions/sources/xarray/coordinates.py
+++ b/src/anemoi/datasets/create/functions/sources/xarray/coordinates.py
@@ -186,6 +186,10 @@ class Coordinate:
         """
         values = self.variable.values
 
+        # Check if dimension is 0D
+        if not isinstance(values,(list, np.ndarray)):
+            values = [values]
+
         # Assume the array is sorted
         index = np.searchsorted(values, value)
 
@@ -214,6 +218,10 @@ class Coordinate:
             The indices of the values in the coordinate, or None if not found.
         """
         values = self.variable.values
+
+        # Check if dimension is 0D
+        if not isinstance(values,(list, np.ndarray)):
+            values = [values]
 
         # Assume the array is sorted
 

--- a/src/anemoi/datasets/create/functions/sources/xarray/metadata.py
+++ b/src/anemoi/datasets/create/functions/sources/xarray/metadata.py
@@ -46,6 +46,7 @@ class _MDMapping:
         """
         self.variable = variable
         self.time = variable.time
+        self.mapping = dict()
         # Aliases
 
     def _from_user(self, key: str) -> str:


### PR DESCRIPTION
## Description

Changes in this PR allow cases where netCDF files / xarray.datasets have dimensions with only a single value.
e.g. only 1 single date / valid_datetime

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

No issue made (yet)

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.

### Documentation

-   [x] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas

<!-- Describe any major updates to the documentation -->

## Additional Notes

