### PR TITLE
feat: save opened anemoi_dataset

### DIFF
--- a/src/anemoi/datasets/create/filters/transform.py
+++ b/src/anemoi/datasets/create/filters/transform.py
@@ -40,8 +40,6 @@ class TransformFilter(Filter):
 
         Parameters
         ----------
-        context : Any
-            The context in which the execution occurs.
         input : ekd.FieldList
             The input data to be transformed.
 

--- a/src/anemoi/datasets/data/__init__.py
+++ b/src/anemoi/datasets/data/__init__.py
@@ -16,6 +16,7 @@ from typing import Set
 # from .dataset import Shape
 # from .dataset import TupleIndex
 from .misc import _open_dataset
+from .misc import _save_dataset
 from .misc import add_dataset_path
 from .misc import add_named_dataset
 
@@ -90,6 +91,21 @@ def open_dataset(*args: Any, **kwargs: Any) -> "Dataset":
     ds.arguments = {"args": args, "kwargs": kwargs}
     ds._check()
     return ds
+
+
+def save_dataset(recipe: dict, zarr_path: str, n_workers: int = 1) -> None:
+    """Open a dataset and save it to disk.
+
+    Parameters
+    ----------
+    recipe : dict
+        Recipe used with open_dataset (not a dataset creation recipe).
+    zarr_path : str
+        Path to store the obtained anemoi dataset to disk.
+    n_workers : int
+        Number of workers to use for parallel processing. If none, sequential processing will be performed.
+    """
+    _save_dataset(recipe, zarr_path, n_workers)
 
 
 def list_dataset_names(*args: Any, **kwargs: Any) -> list[str]:


### PR DESCRIPTION
## Description

Add method to save anemoi dataset  from the recipe used to open it. Write incrementally in a zarr store, adds metadata, recipe used for tracking. Possibility of parallelising without compromising the data order. 

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Some people (including myself) complained on slack the method did not exist.

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [ ] I have ensured that the code is still pip-installable after the changes and runs
-   [x] I have tested that new dependencies themselves are pip-installable.

<!-- List any new dependencies that are required for this change and the justification to add them. -->

### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas


## Additional Notes

