### PR TITLE
fix: forcings

### DIFF
--- a/src/anemoi/datasets/create/input/action.py
+++ b/src/anemoi/datasets/create/input/action.py
@@ -247,8 +247,9 @@ def action_factory(config: Dict[str, Any], context: ActionContext, action_path: 
 
     if cls is None:
         from ..sources import create_source
-
+        
         source = create_source(None, config)
-        return FunctionAction(context, action_path + [key], key, source)
+        
+        return FunctionAction(context=context, action_path=(action_path + [key]),_name=key,source=source,**kwargs)
 
     return cls(context, action_path + [key], *args, **kwargs)

--- a/src/anemoi/datasets/create/input/action.py
+++ b/src/anemoi/datasets/create/input/action.py
@@ -247,9 +247,9 @@ def action_factory(config: Dict[str, Any], context: ActionContext, action_path: 
 
     if cls is None:
         from ..sources import create_source
-        
+
         source = create_source(None, config)
-        
-        return FunctionAction(context=context, action_path=(action_path + [key]),_name=key,source=source,**kwargs)
+
+        return FunctionAction(context=context, action_path=(action_path + [key]), _name=key, source=source, **kwargs)
 
     return cls(context, action_path + [key], *args, **kwargs)

--- a/src/anemoi/datasets/create/input/function.py
+++ b/src/anemoi/datasets/create/input/function.py
@@ -178,6 +178,7 @@ class FunctionResult(Result):
         assert isinstance(action, Action), type(action)
         self.action: Action = action
         self.args, self.kwargs = substitute(context, (self.action.args, self.action.kwargs))
+
     def _trace_datasource(self, *args: Any, **kwargs: Any) -> str:
         """Traces the datasource for the given arguments.
 

--- a/src/anemoi/datasets/create/input/function.py
+++ b/src/anemoi/datasets/create/input/function.py
@@ -177,9 +177,7 @@ class FunctionResult(Result):
         super().__init__(context, action_path, group_of_dates)
         assert isinstance(action, Action), type(action)
         self.action: Action = action
-
         self.args, self.kwargs = substitute(context, (self.action.args, self.action.kwargs))
-
     def _trace_datasource(self, *args: Any, **kwargs: Any) -> str:
         """Traces the datasource for the given arguments.
 
@@ -205,12 +203,11 @@ class FunctionResult(Result):
         """Returns the datasource for the function result."""
         args, kwargs = resolve(self.context, (self.args, self.kwargs))
         self.action.source.context = FunctionContext(self)
-
+        self.action.source.args = args
+        self.action.source.kwargs = kwargs
         return _tidy(
             self.action.source.execute(
                 self.group_of_dates,  # Will provide a list of datetime objects
-                *args,
-                **kwargs,
             )
         )
 

--- a/src/anemoi/datasets/create/sources/forcings.py
+++ b/src/anemoi/datasets/create/sources/forcings.py
@@ -9,14 +9,14 @@
 
 from typing import Any
 from typing import List
-
+from anemoi.datasets.dates.groups import GroupOfDates
 from earthkit.data import from_source
 
 from .legacy import legacy_source
 
 
 @legacy_source(__file__)
-def forcings(context: Any, dates: List[str], template: str, param: str) -> Any:
+def forcings(context: Any, dates: GroupOfDates, template: str, param: str) -> Any:
     """Loads forcing data from a specified source.
 
     Parameters
@@ -36,7 +36,7 @@ def forcings(context: Any, dates: List[str], template: str, param: str) -> Any:
         Loaded forcing data.
     """
     context.trace("✅", f"from_source(forcings, {template}, {param}")
-    return from_source("forcings", source_or_dataset=template, date=dates, param=param)
+    return from_source("forcings", source_or_dataset=template, date=dates.dates, param=param)
 
 
 execute = forcings

--- a/src/anemoi/datasets/create/sources/forcings.py
+++ b/src/anemoi/datasets/create/sources/forcings.py
@@ -8,9 +8,10 @@
 # nor does it submit to any jurisdiction.
 
 from typing import Any
-from typing import List
-from anemoi.datasets.dates.groups import GroupOfDates
+
 from earthkit.data import from_source
+
+from anemoi.datasets.dates.groups import GroupOfDates
 
 from .legacy import legacy_source
 


### PR DESCRIPTION
## Description

Attempting to fix the behaviour encountered in the below-mentioned issue:
1. Set the correct input type for the dates in  `forcing` FunctionResult and forward only list of dates to earthkit-data backend
2. Set args kwargs into `FunctionAction` source (otherwise deacorators such as `legacy_source` don't know them).

This code fixes the mentioned issues, but might break other components (although I doubt it).

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

Solving bugs arising in #262 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas
