### PR TITLE
fix: config-dependent group_by

### DIFF
--- a/src/anemoi/datasets/create/config.py
+++ b/src/anemoi/datasets/create/config.py
@@ -243,8 +243,10 @@ class LoadersConfig(Config):
         self.setdefault("licence", "unknown")
         self.setdefault("attribution", "unknown")
 
+
         self.setdefault("build", Config())
-        self.build.setdefault("group_by", "monthly")
+        config["dates"].setdefault("group_by","monthly")
+        self.build["group_by"] = config["dates"]["group_by"]
         self.build.setdefault("use_grib_paramid", False)
         self.build.setdefault("variable_naming", "default")
         variable_naming = dict(
@@ -352,8 +354,9 @@ def set_to_test_mode(cfg: dict) -> None:
     NUMBER_OF_DATES = 4
 
     LOG.warning(f"Running in test mode. Changing the list of dates to use only {NUMBER_OF_DATES}.")
+    
     groups = Groups(**LoadersConfig(cfg).dates)
-
+    
     dates = groups.provider.values
     cfg["dates"] = dict(
         start=dates[0],
@@ -406,7 +409,6 @@ def loader_config(config: dict, is_test: bool = False) -> LoadersConfig:
     if is_test:
         set_to_test_mode(config)
     obj = LoadersConfig(config)
-
     # yaml round trip to check that serialisation works as expected
     copy = obj.get_serialisable_dict()
     copy = yaml.load(yaml.dump(copy), Loader=yaml.SafeLoader)

--- a/src/anemoi/datasets/create/config.py
+++ b/src/anemoi/datasets/create/config.py
@@ -243,9 +243,8 @@ class LoadersConfig(Config):
         self.setdefault("licence", "unknown")
         self.setdefault("attribution", "unknown")
 
-
         self.setdefault("build", Config())
-        config["dates"].setdefault("group_by","monthly")
+        config["dates"].setdefault("group_by", "monthly")
         self.build["group_by"] = config["dates"]["group_by"]
         self.build.setdefault("use_grib_paramid", False)
         self.build.setdefault("variable_naming", "default")
@@ -354,9 +353,9 @@ def set_to_test_mode(cfg: dict) -> None:
     NUMBER_OF_DATES = 4
 
     LOG.warning(f"Running in test mode. Changing the list of dates to use only {NUMBER_OF_DATES}.")
-    
+
     groups = Groups(**LoadersConfig(cfg).dates)
-    
+
     dates = groups.provider.values
     cfg["dates"] = dict(
         start=dates[0],


### PR DESCRIPTION
## Description

Allow group_by to be freely set by recipe, preventing overwriting.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number
Attempt to solve #292 

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable.

### Documentation

-   [x] My code follows the style guidelines of this project
-   [ ] I have updated the documentation and docstrings to reflect the changes
-   [ ] I have added comments to my code, particularly in hard-to-understand areas
