### PR TITLE
chore(deps): Relax s3fs spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ optional-dependencies.xarray = [
   "pandas",
   "planetary-computer",
   "pystac-client",
-  "s3fs>=0.5",
+  "s3fs",
 ]
 
 urls.Changelog = "https://github.com/ecmwf/anemoi-datasets/CHANGELOG.md"


### PR DESCRIPTION
## Description

Setting a minimum version of s3fs in #297 introduced an incompatibility when installing `anemoi-datasets[all]` together with `anemoi-utils[all]`, causing the dependency resolver to look at every single version of boto3. 

There were good reasons for having a minimum s3fs, but we need to find the cause of this conflict with utils first before setting it again.

```
$ pip install anemoi-datasets[all] anemoi-utils[all]
...
Collecting boto3 (from anemoi-datasets[all])
  Using cached boto3-1.35.99-py3-none-any.whl.metadata (6.7 kB)
INFO: pip is looking at multiple versions of boto3 to determine which version is compatible with other requirements. This could take a while.
  Using cached boto3-1.35.98-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.97-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.96-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.95-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.94-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.93-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.92-py3-none-any.whl.metadata (6.7 kB)
INFO: pip is still looking at multiple versions of boto3 to determine which version is compatible with other requirements. This could take a while.
  Using cached boto3-1.35.91-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.90-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.89-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.88-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.87-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.86-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.85-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.84-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.83-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.82-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.81-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.80-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.79-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.78-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.77-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.76-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.75-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.74-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.73-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.72-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.71-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.70-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.69-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.68-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.67-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.66-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.65-py3-none-any.whl.metadata (6.7 kB)
  Using cached boto3-1.35.64-py3-none-any.whl.metadata (6.7 kB)
etc until infinity
```

