### PR TITLE
chore(deps): earthkit-data<0.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ optional-dependencies.comparelam = [
 
 optional-dependencies.create = [
   "cachetools",
-  "earthkit-data[mars]>=0.12.4",
+  "earthkit-data[mars]>=0.12.4,<0.14",
   "earthkit-geo>=0.3",
   "earthkit-meteo>=0.3",
   "eccodes>=2.39.1",


### PR DESCRIPTION
## Description

earthkit-data 0.14 comes with some breaking changes that break creation of datasets, see #320

While we examine the impact of these changes on datasets and the other anemois, temporarily set `earthkit-data<0.14` to get back to a working state.