### PR TITLE
fix: unable to create cutout when dataset vars are ordered differently

### DIFF
--- a/src/anemoi/datasets/data/forwards.py
+++ b/src/anemoi/datasets/data/forwards.py
@@ -392,7 +392,7 @@ class Combined(Forwards):
         ValueError
             If the variables are not the same.
         """
-        if d1.variables != d2.variables:
+        if d1.variables.sort() != d2.variables.sort():
             raise ValueError(f"Incompatible variables: {d1.variables} and {d2.variables} ({d1} {d2})")
 
     def check_same_lengths(self, d1: Dataset, d2: Dataset) -> None:


### PR DESCRIPTION
## Description
When attempting to create a limited area cutout using a dataset definition like this:
```yaml
dataset: 
  cutout:
    - era5-ml88-conus-0p25-2020010100-2020013123-1h-v2.zarr
    - join:
        - era5-ml137t49-geopotential-0p25-2020010100-2020013123-1h-v1.zarr
        - era5-ml137t49-sp-0p25-2020010100-2020013123-1h-v1.zarr
        - era5-ml137t49-temperature-0p25-2020010100-2020013123-1h-v1.zarr
        - era5-ml137t49-uwind-0p25-2020010100-2020013123-1h-v1.zarr
        - era5-ml137t49-vorticity-0p25-2020010100-2020013123-1h-v1.zarr
        - era5-ml137t49-vwind-0p25-2g020010100-2020013123-1h-v1.zarr
        - era5-sfc-all-0p25-2020010100-2020013123-1h-v1.zarr
```

I would get the error:

```
ValueError: Incompatible variables: 
```

This comes from [here](https://github.com/ecmwf/anemoi-datasets/blob/61100819e60f986be8a9aced1151b44305f22b24/src/anemoi/datasets/data/forwards.py#L395). 

Even though the datasets have the same variables, it must be that when I join the boundary dataset, the variables are in a different order.