### PR TITLE
chore: Mark unit and integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,17 @@ version_file = "src/anemoi/datasets/_version.py"
 [tool.isort]
 profile = "black"
 
+[tool.pytest.ini_options]
+testpaths = "tests"
+addopts = [
+  "--strict-config",
+  "--strict-markers",
+]
+markers = [
+  "unit: unit tests",
+  "integration: integration tests",
+]
+
 [tool.mypy]
 strict = false
 exclude = [

--- a/tests/create/test_create.py
+++ b/tests/create/test_create.py
@@ -370,6 +370,7 @@ class Comparer:
         # do not compare tendencies statistics yet, as we don't know yet if they should stay
 
 
+@pytest.mark.integration
 @skip_if_offline
 @pytest.mark.parametrize("name", NAMES)
 @mockup_from_source

--- a/tests/create/test_sources.py
+++ b/tests/create/test_sources.py
@@ -22,6 +22,7 @@ from anemoi.datasets import open_dataset
 from anemoi.datasets.create.testing import create_dataset
 
 
+@pytest.mark.integration
 @skip_if_offline
 def test_grib() -> None:
     """Test the creation of a dataset from GRIB files.
@@ -53,6 +54,7 @@ def test_grib() -> None:
     assert ds.shape == (8, 12, 1, 162)
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(
     sys.version_info < (3, 10), reason="Type hints from anemoi-transform are not compatible with Python < 3.10"
 )
@@ -93,6 +95,7 @@ def test_grib_gridfile() -> None:
     assert ds.variables == ["2t"]
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(
     sys.version_info < (3, 10), reason="Type hints from anemoi-transform are not compatible with Python < 3.10"
 )
@@ -166,6 +169,7 @@ def test_grib_gridfile_with_refinement_level(refinement_level_c: str, shape: tup
     assert ds.data[ds.to_index(date=0, variable="sin_latitude", member=0)].min() < -0.9
 
 
+@pytest.mark.integration
 @skip_if_offline
 def test_netcdf() -> None:
     """Test for NetCDF files.
@@ -189,6 +193,7 @@ def test_netcdf() -> None:
     assert ds.shape == (2, 2, 1, 162)
 
 
+@pytest.mark.integration
 @skip_missing_packages("fstd", "rpnpy.librmn")
 def test_eccs_fstd() -> None:
     """Test for 'fstd' files from ECCC."""
@@ -211,6 +216,7 @@ def test_eccs_fstd() -> None:
     assert ds.shape == (2, 2, 1, 162)
 
 
+@pytest.mark.integration
 @skip_slow_tests
 @skip_if_offline
 @skip_missing_packages("kerchunk", "s3fs")

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -14,6 +14,7 @@ import pytest
 from anemoi.datasets.create.chunks import ChunkFilter
 
 
+@pytest.mark.unit
 def test_chunk_filter():
     """Test the ChunkFilter class with various inputs and scenarios.
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -562,6 +562,7 @@ def simple_row(date: datetime.datetime, vars: str) -> np.ndarray:
     return make_row(*values)
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_simple() -> None:
     """Test a simple dataset."""
@@ -580,6 +581,7 @@ def test_simple() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_concat() -> None:
     """Test concatenating datasets."""
@@ -601,6 +603,7 @@ def test_concat() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_join_1() -> None:
     """Test joining datasets (case 1)."""
@@ -620,6 +623,7 @@ def test_join_1() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_join_2() -> None:
     """Test joining datasets (case 2)."""
@@ -648,6 +652,7 @@ def test_join_2() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_join_3() -> None:
     """Test joining datasets (case 3)."""
@@ -674,6 +679,7 @@ def test_join_3() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_padding_1() -> None:
     """Test subsetting a dataset (case 2)."""
@@ -693,6 +699,7 @@ def test_padding_1() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_subset_1() -> None:
     """Test subsetting a dataset (case 1)."""
@@ -711,6 +718,7 @@ def test_subset_1() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_subset_2() -> None:
     """Test subsetting a dataset (case 2)."""
@@ -729,6 +737,7 @@ def test_subset_2() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_subset_3() -> None:
     """Test subsetting a dataset (case 3)."""
@@ -747,6 +756,7 @@ def test_subset_3() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_subset_4() -> None:
     """Test subsetting a dataset (case 4)."""
@@ -765,6 +775,7 @@ def test_subset_4() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_subset_5() -> None:
     """Test subsetting a dataset (case 5)."""
@@ -783,6 +794,7 @@ def test_subset_5() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_subset_6() -> None:
     """Test subsetting a dataset (case 6)."""
@@ -801,6 +813,7 @@ def test_subset_6() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_subset_7() -> None:
     """Test subsetting a dataset (case 7)."""
@@ -819,6 +832,7 @@ def test_subset_7() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_subset_8() -> None:
     """Test subsetting a dataset (case 8)."""
@@ -841,6 +855,7 @@ def test_subset_8() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_select_1() -> None:
     """Test selecting variables from a dataset (case 1)."""
@@ -859,6 +874,7 @@ def test_select_1() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_select_2() -> None:
     """Test selecting variables from a dataset (case 2)."""
@@ -877,6 +893,7 @@ def test_select_2() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_select_3() -> None:
     """Test selecting variables from a dataset (case 3)."""
@@ -895,6 +912,7 @@ def test_select_3() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_rename() -> None:
     """Test renaming variables in a dataset."""
@@ -915,6 +933,7 @@ def test_rename() -> None:
     test.same_stats(test.ds, open_dataset("test-2021-2021-6h-o96-abcd"), "xbyd", "abcd")
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_drop() -> None:
     """Test dropping variables from a dataset."""
@@ -933,6 +952,7 @@ def test_drop() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_reorder_1() -> None:
     """Test reordering variables in a dataset (case 1)."""
@@ -951,6 +971,7 @@ def test_reorder_1() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_reorder_2() -> None:
     """Test reordering variables in a dataset (case 2)."""
@@ -969,6 +990,7 @@ def test_reorder_2() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_constructor_1() -> None:
     """Test dataset constructor (case 1)."""
@@ -991,6 +1013,7 @@ def test_constructor_1() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_constructor_2() -> None:
     """Test dataset constructor (case 2)."""
@@ -1014,6 +1037,7 @@ def test_constructor_2() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_constructor_3() -> None:
     """Test dataset constructor (case 3)."""
@@ -1039,6 +1063,7 @@ def test_constructor_3() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_constructor_4() -> None:
     """Test dataset constructor (case 4)."""
@@ -1063,6 +1088,7 @@ def test_constructor_4() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_constructor_5() -> None:
     """Test dataset constructor (case 5)."""
@@ -1095,6 +1121,7 @@ def test_constructor_5() -> None:
     test.same_stats(test.ds, open_dataset("test-2021-2021-6h-o96-abcd-2"), "abzt", "abcd")
 
 
+@pytest.mark.unit
 @mockup_open_zarr
 def test_dates() -> None:
     """Test date handling functions."""
@@ -1119,6 +1146,7 @@ def test_dates() -> None:
     assert as_last_date("2021-01-01", dates) == np.datetime64("2021-01-01T23:59:59")
 
 
+@pytest.mark.unit
 @mockup_open_zarr
 def test_dates_using_list() -> None:
     """Test date handling functions using a list of dates."""
@@ -1132,6 +1160,7 @@ def test_dates_using_list() -> None:
     assert as_last_date("2021", dates) == np.datetime64("2021-12-31T06:00:00")
 
 
+@pytest.mark.unit
 @mockup_open_zarr
 def test_dates_using_list_2() -> None:
     """Test date handling functions using a list of dates (case 2)."""
@@ -1178,6 +1207,7 @@ def test_dates_using_list_2() -> None:
     assert dates[-1] == as_last_date("100%", dates)
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_slice_1() -> None:
     """Test slicing a dataset (case 1)."""
@@ -1196,6 +1226,7 @@ def test_slice_1() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_slice_2() -> None:
     """Test slicing a dataset (case 2)."""
@@ -1214,6 +1245,7 @@ def test_slice_2() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_slice_3() -> None:
     """Test slicing a dataset (case 3)."""
@@ -1234,6 +1266,7 @@ def test_slice_3() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_slice_4() -> None:
     """Test slicing a dataset (case 4)."""
@@ -1252,6 +1285,7 @@ def test_slice_4() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_slice_5() -> None:
     """Test slicing a dataset (case 5)."""
@@ -1273,6 +1307,7 @@ def test_slice_5() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_ensemble_1() -> None:
     """Test ensemble datasets (case 1)."""
@@ -1302,6 +1337,7 @@ def test_ensemble_1() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_ensemble_2() -> None:
     """Test ensemble datasets (case 2)."""
@@ -1332,6 +1368,7 @@ def test_ensemble_2() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_ensemble_3() -> None:
     """Test ensemble datasets (case 3)."""
@@ -1362,6 +1399,7 @@ def test_ensemble_3() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_grids() -> None:
     """Test datasets with different grids."""
@@ -1409,6 +1447,7 @@ def test_grids() -> None:
     assert (test.ds.latitudes == np.concatenate([ds1.latitudes, ds2.latitudes])).all()
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_statistics() -> None:
     """Test datasets with statistics."""
@@ -1430,6 +1469,7 @@ def test_statistics() -> None:
     )
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_cropping() -> None:
     """Test cropping a dataset."""
@@ -1440,6 +1480,7 @@ def test_cropping() -> None:
     assert test.ds.shape == (365 * 4, 4, 1, 8)
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_invalid_trim_edge() -> None:
     """Test that exception raised when attempting to trim a 1D dataset"""

--- a/tests/test_data_gridded.py
+++ b/tests/test_data_gridded.py
@@ -19,6 +19,7 @@ from typing import Union
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 import zarr
 from anemoi.utils.dates import frequency_to_string
 from anemoi.utils.dates import frequency_to_timedelta
@@ -503,6 +504,7 @@ class DatasetTester:
             t[::step]
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_trim_edge_simple() -> None:
     """Test trimming the edges of a dataset."""
@@ -516,6 +518,7 @@ def test_trim_edge_simple() -> None:
     assert test.ds.shape == (365 * 4, 4, 1, np.prod(expected_field_shape)), test.ds.shape
 
 
+@pytest.mark.integration
 @mockup_open_zarr
 def test_trim_edge_zeros() -> None:
     """Test trimming the edges of a dataset when edges are 0"""

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -97,6 +97,7 @@ def default_end(*args: Any, **kwargs: Any) -> datetime.datetime:
     return default_statistics_dates(date_list(*args, **kwargs))[1]
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("y", [2000, 2001, 2002, 2003, 2004, 2005, 1900, 2100])
 @pytest.mark.parametrize("as_numpy", [True, False])
 def test_default_statistics_dates(y: int, as_numpy: bool) -> None:
@@ -135,6 +136,7 @@ def test_default_statistics_dates(y: int, as_numpy: bool) -> None:
     assert default_end((y, 1, 1), (y + 11, 12, 23), 12, as_numpy=as_numpy) == datetime.datetime(y + 10, 12, 31, 12)
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize("as_numpy", [True, False])
 def test_default_statistics_dates_80_percent(as_numpy: bool) -> None:
     """Test the default_statistics_dates function for datasets less than 10 years.

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -7,12 +7,13 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-
 import numpy as np
+import pytest
 
 from anemoi.datasets.data.indexing import length_to_slices
 
 
+@pytest.mark.unit
 def test_length_to_slices() -> None:
     """Test the length_to_slices function with various inputs."""
     lengths = [5, 7, 11, 13]

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -120,12 +120,14 @@ def _test(ds, nb_dates=None):
         assert np.all(statistics[grp][key] == v), (key, statistics[grp][key], v)
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(not os.path.exists("../../data/vz/obs-2018-11.vz"), reason="File not found")
 def test_open():
     ds = open_dataset("../../data/vz/obs-2018-11.vz")
     _test(ds)
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(not os.path.exists("../../data/vz/obs-2018-11.vz"), reason="File not found")
 def test_open_with_subset_dates():
     ds = open_dataset(
@@ -140,6 +142,7 @@ def test_open_with_subset_dates():
     _test(ds, nb_dates=8)
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(not os.path.exists("../../data/vz/obs-2018-11.vz"), reason="File not found")
 def test_open_with_subset_select():
     ds = open_dataset(

--- a/tests/xarray/test_opendap.py
+++ b/tests/xarray/test_opendap.py
@@ -6,8 +6,7 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
-
-
+import pytest
 import xarray as xr
 from anemoi.utils.testing import skip_if_offline
 from anemoi.utils.testing import skip_slow_tests
@@ -16,6 +15,7 @@ from anemoi.datasets.create.sources.xarray import XarrayFieldList
 from anemoi.datasets.testing import assert_field_list
 
 
+@pytest.mark.unit
 @skip_if_offline
 @skip_slow_tests
 def test_opendap() -> None:

--- a/tests/xarray/test_samples.py
+++ b/tests/xarray/test_samples.py
@@ -60,6 +60,7 @@ def _test_samples(n: int, check_skip: bool = True) -> None:
     assert_field_list(fs, **kwargs)
 
 
+@pytest.mark.unit
 @skip_if_offline
 @skip_slow_tests
 @pytest.mark.parametrize("n", SAMPLES)

--- a/tests/xarray/test_zarr.py
+++ b/tests/xarray/test_zarr.py
@@ -6,8 +6,7 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
-
-
+import pytest
 import xarray as xr
 from anemoi.utils.testing import skip_if_offline
 from anemoi.utils.testing import skip_missing_packages
@@ -17,6 +16,7 @@ from anemoi.datasets.data.stores import name_to_zarr_store
 from anemoi.datasets.testing import assert_field_list
 
 
+@pytest.mark.unit
 @skip_if_offline
 @skip_missing_packages("gcsfs")
 def test_arco_era5_1() -> None:
@@ -36,6 +36,7 @@ def test_arco_era5_1() -> None:
     )
 
 
+@pytest.mark.unit
 @skip_if_offline
 @skip_missing_packages("gcsfs")
 def test_arco_era5_2() -> None:
@@ -55,6 +56,7 @@ def test_arco_era5_2() -> None:
     )
 
 
+@pytest.mark.unit
 @skip_if_offline
 @skip_missing_packages("gcsfs")
 def test_weatherbench() -> None:
@@ -84,6 +86,7 @@ def test_weatherbench() -> None:
     )
 
 
+@pytest.mark.unit
 @skip_if_offline
 @skip_missing_packages("aiohttp")
 def test_inca_one_date() -> None:
@@ -104,6 +107,7 @@ def test_inca_one_date() -> None:
     print(fs[0].datetime())
 
 
+@pytest.mark.unit
 @skip_if_offline
 @skip_missing_packages("gcsfs")
 def test_noaa_replay() -> None:
@@ -133,6 +137,7 @@ def test_noaa_replay() -> None:
     )
 
 
+@pytest.mark.unit
 @skip_if_offline
 @skip_missing_packages("planetary_computer", "adlfs")
 def test_planetary_computer_conus404() -> None:


### PR DESCRIPTION
## Description
Mark unit and integration tests and add pytest config to pyproject.toml.

## What problem does this change solve?
This change makes it easier to run subsets of the tests, e.g. `pytest -m unit` to run only unit tests, or `pytest -m integration` to run only integration tests.

## What issue or task does this change relate to?
n/a

##  Additional notes ##
n/a

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
