### PR TITLE
feature: Use pytest-xdist to run tests in parallel.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ optional-dependencies.remote = [
 optional-dependencies.tests = [
   "anemoi-datasets[xarray]",
   "pytest",
+  "pytest-xdist",
 ]
 
 optional-dependencies.xarray = [
@@ -130,6 +131,13 @@ version_file = "src/anemoi/datasets/_version.py"
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+testpaths = "tests"
+addopts = [
+  "--numprocesses=auto",
+  "--strict-config",
+]
 
 [tool.mypy]
 strict = false


### PR DESCRIPTION
## Description
Use pytest-xdist to run tests in parallel.

## What problem does this change solve?
Running the tests in parallel can reduce the amount of time for the tests to run.

## What issue or task does this change relate to?
n/a

##  Additional notes ##
This change introduces an additional dependency on `pytest-xdist` which may be undesirable. Individual users could choose to install this manually, but including this in the `pyproject.toml` means that users will benefit by default.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
