### PR TITLE
fix/remove 2 layers of build function

### DIFF
--- a/src/anemoi/datasets/create/__init__.py
+++ b/src/anemoi/datasets/create/__init__.py
@@ -35,7 +35,7 @@ from anemoi.datasets.dates.groups import Groups
 from .check import DatasetName, check_data_values
 from .chunks import ChunkFilter
 from .config import build_output, loader_config
-from .input import InputBuilder, build_input
+from .input import InputBuilder
 from .statistics import (
     Summary,
     TmpStatistics,
@@ -576,32 +576,32 @@ class HasElementForDataMixin:
         # LOG.info("%s", self.input)
 
 
-def build_input_(main_config: Any, output_config: Any) -> Any:
-    """Build the input for the dataset.
-
-    Parameters
-    ----------
-    main_config : Any
-        The main configuration.
-    output_config : Any
-        The output configuration.
-
-    Returns
-    -------
-    Any
-        The input builder.
-    """
-    builder = build_input(
-        main_config.input,
-        data_sources=main_config.get("data_sources", {}),
-        order_by=output_config.order_by,
-        flatten_grid=output_config.flatten_grid,
-        remapping=build_remapping(output_config.remapping),
-        use_grib_paramid=main_config.build.use_grib_paramid,
-    )
-    LOG.debug("✅ INPUT_BUILDER")
-    LOG.debug(builder)
-    return builder
+#  def build_input_(main_config: Any, output_config: Any) -> Any:
+#      """Build the input for the dataset.
+#
+#      Parameters
+#      ----------
+#      main_config : Any
+#          The main configuration.
+#      output_config : Any
+#          The output configuration.
+#
+#      Returns
+#      -------
+#      Any
+#          The input builder.
+#      """
+#      builder = build_input(
+#          main_config.input,
+#          data_sources=main_config.get("data_sources", {}),
+#          order_by=output_config.order_by,
+#          flatten_grid=output_config.flatten_grid,
+#          remapping=build_remapping(output_config.remapping),
+#          use_grib_paramid=main_config.build.use_grib_paramid,
+#      )
+#      LOG.debug("✅ INPUT_BUILDER")
+#      LOG.debug(builder)
+#      return builder
 
 
 class Init(Actor, HasRegistryMixin, HasStatisticTempMixin, HasElementForDataMixin):

--- a/src/anemoi/datasets/create/__init__.py
+++ b/src/anemoi/datasets/create/__init__.py
@@ -797,10 +797,7 @@ class Init(Actor, HasRegistryMixin, HasStatisticTempMixin, HasElementForDataMixi
 
         self.registry.add_to_history("init finished")
 
-        assert chunks == self.dataset.get_zarr_chunks(), (
-            chunks,
-            self.dataset.get_zarr_chunks(),
-        )
+        assert chunks == self.dataset.get_zarr_chunks(), (chunks, self.dataset.get_zarr_chunks())
 
         # Return the number of groups to process, so we can show a nice progress bar
         return len(lengths)
@@ -871,11 +868,7 @@ class Load(Actor, HasRegistryMixin, HasStatisticTempMixin, HasElementForDataMixi
             LOG.debug(f"Building data for group {igroup}/{self.n_groups}")
 
             result = self.input.select(group_of_dates=group)
-            assert result.group_of_dates == group, (
-                len(result.group_of_dates),
-                len(group),
-                group,
-            )
+            assert result.group_of_dates == group, (len(result.group_of_dates), len(group), group)
 
             # There are several groups.
             # There is one result to load for each group.
@@ -1068,12 +1061,7 @@ class Cleanup(Actor, HasRegistryMixin, HasStatisticTempMixin):
         self.statistics_temp_dir = statistics_temp_dir
         self.additinon_temp_dir = statistics_temp_dir
         self.actors = [
-            _InitAdditions(
-                path,
-                delta=d,
-                use_threads=use_threads,
-                statistics_temp_dir=statistics_temp_dir,
-            )
+            _InitAdditions(path, delta=d, use_threads=use_threads, statistics_temp_dir=statistics_temp_dir)
             for d in delta
         ]
 
@@ -1192,14 +1180,7 @@ class DeltaDataset:
 class _InitAdditions(Actor, HasRegistryMixin, AdditionsMixin):
     """A class to initialize dataset additions."""
 
-    def __init__(
-        self,
-        path: str,
-        delta: str,
-        use_threads: bool = False,
-        progress: Any = None,
-        **kwargs: Any,
-    ):
+    def __init__(self, path: str, delta: str, use_threads: bool = False, progress: Any = None, **kwargs: Any):
         """Initialize an _InitAdditions instance.
 
         Parameters
@@ -1315,14 +1296,7 @@ class _RunAdditions(Actor, HasRegistryMixin, AdditionsMixin):
 class _FinaliseAdditions(Actor, HasRegistryMixin, AdditionsMixin):
     """A class to finalize dataset additions."""
 
-    def __init__(
-        self,
-        path: str,
-        delta: str,
-        use_threads: bool = False,
-        progress: Any = None,
-        **kwargs: Any,
-    ):
+    def __init__(self, path: str, delta: str, use_threads: bool = False, progress: Any = None, **kwargs: Any):
         """Initialize a _FinaliseAdditions instance.
 
         Parameters
@@ -1425,13 +1399,7 @@ class _FinaliseAdditions(Actor, HasRegistryMixin, AdditionsMixin):
         # x[- 1e-15 < (x / (np.sqrt(squares / count) + np.abs(mean))) < 0] = 0
         # remove negative variance due to numerical errors
         for i, name in enumerate(self.variables):
-            x[i] = fix_variance(
-                x[i],
-                name,
-                agg["count"][i : i + 1],
-                agg["sums"][i : i + 1],
-                agg["squares"][i : i + 1],
-            )
+            x[i] = fix_variance(x[i], name, agg["count"][i : i + 1], agg["sums"][i : i + 1], agg["squares"][i : i + 1])
         check_variance(x, self.variables, minimum, maximum, mean, count, sums, squares)
 
         stdev = np.sqrt(x)
@@ -1461,16 +1429,7 @@ class _FinaliseAdditions(Actor, HasRegistryMixin, AdditionsMixin):
         summary : Summary
             The summary to write.
         """
-        for k in [
-            "mean",
-            "stdev",
-            "minimum",
-            "maximum",
-            "sums",
-            "squares",
-            "count",
-            "has_nans",
-        ]:
+        for k in ["mean", "stdev", "minimum", "maximum", "sums", "squares", "count", "has_nans"]:
             name = f"statistics_tendencies_{frequency_to_string(self.delta)}_{k}"
             self.dataset.add_dataset(name=name, array=summary[k], dimensions=("variable",))
         self.registry.add_to_history(f"compute_statistics_{self.__class__.__name__.lower()}_end")

--- a/src/anemoi/datasets/create/__init__.py
+++ b/src/anemoi/datasets/create/__init__.py
@@ -564,36 +564,6 @@ class HasElementForDataMixin:
         LOG.debug("✅ INPUT_BUILDER")
         LOG.debug(self.input)
 
-        # LOG.info("%s", self.input)
-
-
-#  def build_input_(main_config: Any, output_config: Any) -> Any:
-#      """Build the input for the dataset.
-#
-#      Parameters
-#      ----------
-#      main_config : Any
-#          The main configuration.
-#      output_config : Any
-#          The output configuration.
-#
-#      Returns
-#      -------
-#      Any
-#          The input builder.
-#      """
-#      builder = build_input(
-#          main_config.input,
-#          data_sources=main_config.get("data_sources", {}),
-#          order_by=output_config.order_by,
-#          flatten_grid=output_config.flatten_grid,
-#          remapping=build_remapping(output_config.remapping),
-#          use_grib_paramid=main_config.build.use_grib_paramid,
-#      )
-#      LOG.debug("✅ INPUT_BUILDER")
-#      LOG.debug(builder)
-#      return builder
-
 
 class Init(Actor, HasRegistryMixin, HasStatisticTempMixin, HasElementForDataMixin):
     """A class to initialize a new dataset."""

--- a/src/anemoi/datasets/create/input/__init__.py
+++ b/src/anemoi/datasets/create/input/__init__.py
@@ -9,7 +9,8 @@
 
 import logging
 from copy import deepcopy
-from typing import Any, Union
+from typing import Any
+from typing import Union
 
 from anemoi.datasets.dates.groups import GroupOfDates
 
@@ -27,9 +28,7 @@ class Context:
 class InputBuilder:
     """Builder class for creating input data from configuration and data sources."""
 
-    def __init__(
-        self, config: dict, data_sources: Union[dict, list], **kwargs: Any
-    ) -> None:
+    def __init__(self, config: dict, data_sources: Union[dict, list], **kwargs: Any) -> None:
         """Initialize the InputBuilder.
 
         Parameters
@@ -68,7 +67,8 @@ class InputBuilder:
         Any
             Selected data.
         """
-        from .action import ActionContext, action_factory
+        from .action import ActionContext
+        from .action import action_factory
 
         """This changes the context."""
         context = ActionContext(**self.kwargs)
@@ -83,7 +83,8 @@ class InputBuilder:
         str
             String representation.
         """
-        from .action import ActionContext, action_factory
+        from .action import ActionContext
+        from .action import action_factory
 
         context = ActionContext(**self.kwargs)
         a = action_factory(self.config, context, self.action_path)

--- a/src/anemoi/datasets/create/input/__init__.py
+++ b/src/anemoi/datasets/create/input/__init__.py
@@ -9,8 +9,7 @@
 
 import logging
 from copy import deepcopy
-from typing import Any
-from typing import Union
+from typing import Any, Union
 
 from anemoi.datasets.dates.groups import GroupOfDates
 
@@ -28,7 +27,9 @@ class Context:
 class InputBuilder:
     """Builder class for creating input data from configuration and data sources."""
 
-    def __init__(self, config: dict, data_sources: Union[dict, list], **kwargs: Any) -> None:
+    def __init__(
+        self, config: dict, data_sources: Union[dict, list], **kwargs: Any
+    ) -> None:
         """Initialize the InputBuilder.
 
         Parameters
@@ -67,8 +68,7 @@ class InputBuilder:
         Any
             Selected data.
         """
-        from .action import ActionContext
-        from .action import action_factory
+        from .action import ActionContext, action_factory
 
         """This changes the context."""
         context = ActionContext(**self.kwargs)
@@ -83,8 +83,7 @@ class InputBuilder:
         str
             String representation.
         """
-        from .action import ActionContext
-        from .action import action_factory
+        from .action import ActionContext, action_factory
 
         context = ActionContext(**self.kwargs)
         a = action_factory(self.config, context, self.action_path)
@@ -104,23 +103,3 @@ class InputBuilder:
             Trace string.
         """
         return f"InputBuilder({group_of_dates})"
-
-
-def build_input(config: dict, data_sources: Union[dict, list], **kwargs: Any) -> InputBuilder:
-    """Build an InputBuilder instance.
-
-    Parameters
-    ----------
-    config : dict
-        Configuration dictionary.
-    data_sources : Union[dict, list]
-        Data sources.
-    **kwargs : Any
-        Additional keyword arguments.
-
-    Returns
-    -------
-    InputBuilder
-        An instance of InputBuilder.
-    """
-    return InputBuilder(config, data_sources, **kwargs)


### PR DESCRIPTION
## Description
Summary
This PR removes the indirection around build_input_ / build_input and instead constructs InputBuilder directly. Previously, calls to build_input_ would forward arguments to build_input, which then instantiated InputBuilder and passed it back two layers up. That chain made the code harder to follow. Now, in create_elements(...), we simply call InputBuilder(...) with the necessary parameters, eliminating the extra function call and improving readability.

## What problem does this change solve?
Improves readablity

## What issue or task does this change relate to?
None

##  Additional notes ##
None 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***
