### PR TITLE
fix: Small fixes to allow a smoother incremental creation of an anemoi-dataset

### DIFF
--- a/src/anemoi/datasets/create/__init__.py
+++ b/src/anemoi/datasets/create/__init__.py
@@ -880,7 +880,9 @@ class Load(Actor, HasRegistryMixin, HasStatisticTempMixin, HasElementForDataMixi
                 continue
             if self.registry.get_flag(igroup):
                 LOG.info(f" -> Skipping {igroup} total={len(self.groups)} (already done)")
-                continue
+                LOG.info(f"Reloading {igroup}...")
+                # TODO option to overwrite on load as with --init
+                # continue 
 
             # assert isinstance(group[0], datetime.datetime), type(group[0])
             LOG.debug(f"Building data for group {igroup}/{self.n_groups}")
@@ -1537,7 +1539,9 @@ class Statistics(Actor, HasStatisticTempMixin, HasRegistryMixin):
         stats = self.tmp_statistics.get_aggregated(dates, variables, self.allow_nans)
 
         LOG.info(stats)
-
+        flags = self.registry.get_flags(sync=False)
+        false_indices = [i for i, val in enumerate(flags) if val == False]
+        print(false_indices)
         if not all(self.registry.get_flags(sync=False)):
             raise Exception(f"❗Zarr {self.path} is not fully built, not writing statistics into dataset.")
 

--- a/src/anemoi/datasets/create/__init__.py
+++ b/src/anemoi/datasets/create/__init__.py
@@ -1539,9 +1539,6 @@ class Statistics(Actor, HasStatisticTempMixin, HasRegistryMixin):
         stats = self.tmp_statistics.get_aggregated(dates, variables, self.allow_nans)
 
         LOG.info(stats)
-        flags = self.registry.get_flags(sync=False)
-        false_indices = [i for i, val in enumerate(flags) if val == False]
-        print(false_indices)
         if not all(self.registry.get_flags(sync=False)):
             raise Exception(f"❗Zarr {self.path} is not fully built, not writing statistics into dataset.")
 

--- a/src/anemoi/datasets/create/statistics/__init__.py
+++ b/src/anemoi/datasets/create/statistics/__init__.py
@@ -361,6 +361,9 @@ class TmpStatistics:
             pickle.dump((key, dates, data), f)
         shutil.move(tmp_path, path)
 
+        # ✅ Assert that the final file exists after writing
+        assert os.path.exists(path), f"Failed to write data to {path}"
+
         LOG.debug(f"Written statistics data for {len(dates)} dates in {path} ({dates})")
 
     def _gather_data(self) -> tuple[str, list[datetime.datetime], dict]:


### PR DESCRIPTION
## Description
- Allow anemoi-dataset load to run even if that part was already loaded
- Assert that the compressed statistics file is created successfully

## What problem does this change solve?
Small fixes to solve issues of missing statistics files on some anemoi-datasets load jobs.
