### PR TITLE
fix: define the missing forwards_subclass_metadata_specific method in the ZipBase class

### DIFF
--- a/src/anemoi/datasets/data/xy.py
+++ b/src/anemoi/datasets/data/xy.py
@@ -81,7 +81,11 @@ class ZipBase(Combined):
         Node
             Tree representation of the datasets.
         """
-        return Node(self, [d.tree() for d in self.datasets], check_compatibility=self._check_compatibility)
+        return Node(
+            self,
+            [d.tree() for d in self.datasets],
+            check_compatibility=self._check_compatibility,
+        )
 
     def __len__(self) -> int:
         """Get the length of the smallest dataset.
@@ -209,6 +213,10 @@ class ZipBase(Combined):
         """
         if self._check_compatibility:
             super().check_compatibility(d1, d2)
+
+    def forwards_subclass_metadata_specific(self) -> Dict[str, Any]:
+        """Get the metadata specific to the subclass."""
+        return {}
 
 
 class Zip(ZipBase):


### PR DESCRIPTION
## Description

This PR defines the `forwards_subclass_metadata_specific` method in the  `ZipBase `class. This definition seems mandatory as `ZipBase` inherits from the `Forward`s class which declares an abstract method `forwards_subclass_metadata_specific`, see: [https://docs.python.org/3/library/abc.html#abc.abstractmethod](https://docs.python.org/3/library/abc.html#abc.abstractmethod)

## What problem does this change solve?

This change solves the following issue:

```
File "/perm/fra6527/venvs/3-aromeds-dev-7e65c1cb35/lib/python3.11/site-packages/anemoi/training/data/datamodule.py", line 98, in data_indices
    return IndexCollection(self.config, self.ds_train.name_to_index)
                                        ^^^^^^^^^^^^^
  File "/usr/local/apps/python3/3.11.10-01/lib/python3.11/functools.py", line 1001, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/perm/fra6527/venvs/3-aromeds-dev-7e65c1cb35/lib/python3.11/site-packages/anemoi/training/data/datamodule.py", line 103, in ds_train
    open_dataset(
  File "/perm/fra6527/venvs/3-aromeds-dev-7e65c1cb35/lib/python3.11/site-packages/anemoi/datasets/data/__init__.py", line 89, in open_dataset
    ds = _open_dataset(*args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/perm/fra6527/venvs/3-aromeds-dev-7e65c1cb35/lib/python3.11/site-packages/anemoi/datasets/data/misc.py", line 506, in _open_dataset
    sets.append(_open(a))
                ^^^^^^^^
  File "/perm/fra6527/venvs/3-aromeds-dev-7e65c1cb35/lib/python3.11/site-packages/anemoi/datasets/data/misc.py", line 384, in _open
    return _open_dataset(**a).mutate()
           ^^^^^^^^^^^^^^^^^^
  File "/perm/fra6527/venvs/3-aromeds-dev-7e65c1cb35/lib/python3.11/site-packages/anemoi/datasets/data/misc.py", line 591, in _open_dataset
    sets.append(_open(a))
                ^^^^^^^^
  File "/perm/fra6527/venvs/3-aromeds-dev-7e65c1cb35/lib/python3.11/site-packages/anemoi/datasets/data/misc.py", line 384, in _open
    return _open_dataset(**a).mutate()
           ^^^^^^^^^^^^^^^^^^
  File "/perm/fra6527/venvs/3-aromeds-dev-7e65c1cb35/lib/python3.11/site-packages/anemoi/datasets/data/misc.py", line 534, in _open_dataset
    return zip_factory(args, kwargs).mutate()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/perm/fra6527/venvs/3-aromeds-dev-7e65c1cb35/lib/python3.11/site-packages/anemoi/datasets/data/xy.py", line 283, in zip_factory
    return Zip(datasets, check_compatibility=check_compatibility)._subset(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Can't instantiate abstract class Zip with abstract method forwards_subclass_metadata_specific
```

that arises when loading a Zip of datasets during training, e.g. with the following dataloader config:

```
prefetch_factor: 2

num_workers:
  training: 4
  validation: 4
  test: 4
  predict: 4
batch_size:
  training: 1
  validation: 1
  test: 1
  predict: 1
# runs only N training batches [N = integer | null]
# if null then we run through all the batches
limit_batches:
  training: null
  validation: null
  test: 20
  predict: 20

# ============
# Dataloader definitions
# These follow the ecml-tools patterns
# You can make these as complicated for merging as you like
# See Readme: https://github.com/ecwmf-lab/ecml-tools/
# ============

select_in: [2t, 10u, 10v, t_850]
select_in_hres: [cos_latitude]
select_out: [2t, 10u, 10v, t_850, tp]

dataset:
  zip:
    - dataset: ${hardware.paths.data}/${hardware.files.dataset_x}
      name: lres
      select: ${dataloader.select_in}
    - dataset: ${hardware.paths.data}/${hardware.files.dataset_y_forcings}
      name: hres
      select: ${dataloader.select_in_hres}
    - dataset: ${hardware.paths.data}/${hardware.files.dataset_y}
      name: out
      select: ${dataloader.select_out}
  adjust: dates

training:
  dataset: ${dataloader.dataset}
  start: 2020
  end: 2022
  frequency: ${data.frequency}

validation:
  dataset: ${dataloader.dataset}
  start: 2023
  end: 2023
  frequency: ${data.frequency}

test:
  dataset: ${dataloader.dataset}
  start: 2024
  end: 2025
  frequency: ${data.frequency}
``` 

##  Additional notes ##

It may be possible to return a relevant metadata dict but I don't know enough of the code to know what to return. 

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
