### PR TITLE
feat: Extend xarray Variable.sel to handle scalar variables

### DIFF
--- a/src/anemoi/datasets/create/sources/xarray_support/variable.py
+++ b/src/anemoi/datasets/create/sources/xarray_support/variable.py
@@ -221,19 +221,22 @@ class Variable:
                 LOG.warning(f"Could not find {k}={v} in {c}")
             return None
 
-        coordinates = [x.reduced(i) if c is x else x for x in self.coordinates]
+        if c.scalar and i == 0:
+            variable = self
+        else:
+            coordinates = [x.reduced(i) if c is x else x for x in self.coordinates]
 
-        metadata = self._metadata.copy()
-        metadata.update({k: v})
+            metadata = self._metadata.copy()
+            metadata.update({k: v})
 
-        variable = Variable(
-            ds=self.ds,
-            variable=self.variable.isel({k: i}),
-            coordinates=coordinates,
-            grid=self.grid,
-            time=self.time,
-            metadata=metadata,
-        )
+            variable = Variable(
+                ds=self.ds,
+                variable=self.variable.isel({k: i}),
+                coordinates=coordinates,
+                grid=self.grid,
+                time=self.time,
+                metadata=metadata,
+            )
 
         return variable.sel(missing, **kwargs)
 

--- a/tests/xarray/test_variable.py
+++ b/tests/xarray/test_variable.py
@@ -1,0 +1,83 @@
+# (C) Copyright 2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import datetime
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from anemoi.datasets.create.sources.xarray_support.coordinates import DateCoordinate
+from anemoi.datasets.create.sources.xarray_support.coordinates import LatitudeCoordinate
+from anemoi.datasets.create.sources.xarray_support.coordinates import LevelCoordinate
+from anemoi.datasets.create.sources.xarray_support.coordinates import LongitudeCoordinate
+from anemoi.datasets.create.sources.xarray_support.coordinates import StepCoordinate
+from anemoi.datasets.create.sources.xarray_support.coordinates import TimeCoordinate
+from anemoi.datasets.create.sources.xarray_support.time import ForecastFromValidTimeAndStep
+from anemoi.datasets.create.sources.xarray_support.variable import Variable
+
+
+@pytest.fixture
+def sample_variable():
+    ds = xr.Dataset(
+        {
+            "temperature": (("time", "pressure", "latitude", "longitude"), np.ones((1, 3, 3, 4))),
+        },
+        coords={
+            "time": ("time", [datetime.datetime(2025, 2, 3)]),
+            "forecast_period": ([0]),
+            "forecast_reference_time": ([datetime.datetime(2025, 2, 3)]),
+            "pressure": ("pressure", [850, 925, 1000]),
+            "latitude": ("latitude", np.linspace(-90, 90, 3)),
+            "longitude": ("longitude", np.linspace(-180, 180, 4)),
+        },
+    )
+
+    time_coordinates = [
+        TimeCoordinate(ds["time"]),
+        StepCoordinate(ds["forecast_period"]),
+        DateCoordinate(ds["forecast_reference_time"]),
+    ]
+
+    time = ForecastFromValidTimeAndStep(*time_coordinates)
+    coordinates = [
+        *time_coordinates,
+        LevelCoordinate(ds["pressure"], "pl"),
+        LatitudeCoordinate(ds["latitude"]),
+        LongitudeCoordinate(ds["longitude"]),
+    ]
+
+    variable = Variable(ds=ds, variable=ds["temperature"], coordinates=coordinates, grid=None, time=time, metadata={})
+    return variable
+
+
+def test_sel_single_value(sample_variable):
+    result = sample_variable.sel({}, pressure=850)
+    print(result.variable["pressure"].values)
+    assert result.variable["pressure"].values == 850
+
+
+def test_sel_multiple_values(sample_variable):
+    result = sample_variable.sel({}, pressure=[850, 925])
+    assert np.array_equal(result.variable["pressure"].values, np.array([850, 925]))
+
+
+def test_sel_from_scalar_time(sample_variable):
+    result = sample_variable.sel({}, valid_datetime=datetime.datetime(2025, 2, 3))
+    assert np.array_equal(
+        result.variable["time"].values, np.array([datetime.datetime(2025, 2, 3)], dtype="datetime64[ns]")
+    )
+
+
+def test_sel_multiple_coordinates(sample_variable):
+    result = sample_variable.sel({}, valid_datetime=datetime.datetime(2025, 2, 3), pressure=[850, 925])
+    assert np.array_equal(result.variable["pressure"].values, np.array([850, 925]))
+    assert np.array_equal(
+        result.variable["time"].values, np.array([datetime.datetime(2025, 2, 3)], dtype="datetime64[ns]")
+    )


### PR DESCRIPTION
## Description
This modifies the code for `anemoi.datasets.create.sources.xarray_support.variable.Variable.sel()`to handle the situation where a `Variable` is scalar. This also includes some basic unit testing.

## What problem does this change solve?
When trying to create datasets from netcdf files, I would hit an issue when one of my coordinates was a scalar as [this line would fail](https://github.com/ecmwf/anemoi-datasets/blob/2baa24ec5e596221fd06bcc24c0f37c85f3fdeff/src/anemoi/datasets/create/sources/xarray_support/variable.py#L224).

I am working with lots of netcdf files where each netcdf file represents a single time step so the time coordinate is scalar

## What issue or task does this change relate to?
n/a

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
