### PR TITLE
Fix: implement missing abstract method in Zip

### DIFF
--- a/src/anemoi/datasets/data/xy.py
+++ b/src/anemoi/datasets/data/xy.py
@@ -213,7 +213,17 @@ class ZipBase(Combined):
 
 class Zip(ZipBase):
     """Class for handling zipped datasets."""
+    def forwards_subclass_metadata_specific(self) -> Dict[str, Any]:
+        """Returns metadata specific to the Zip subclass.
 
+        Returns
+        -------
+        Dict[str, Any]
+            Metadata specific to the Zip subclass.
+        """
+        # Implement logic specific to the Zip class, if needed.
+        # For now, return an empty dictionary as a placeholder.
+        return {}
     pass
 
 


### PR DESCRIPTION
## Description
This pull request addresses an issue where the `Zip` class could not be instantiated because the abstract method `forwards_subclass_metadata_specific` was not implemented. The `Zip` class inherits this abstract method from the `Forwards` class, and its absence caused a `TypeError` when attempting to use the `Zip` class.

## What problem does this change solve?
This change resolves the `TypeError: Can't instantiate abstract class Zip with abstract method forwards_subclass_metadata_specific` by implementing the `forwards_subclass_metadata_specific` method in the `Zip` class. For now, the method currently returns an empty dictionary as a placeholder.

## What issue or task does this change relate to?
The issue was encountered when calling `open_dataset(zip=[dataset_1, dataset_2])`.

