### PR TITLE
test: replace skip_slow_tests decorator with slow markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ optional-dependencies.remote = [
 optional-dependencies.tests = [
   "anemoi-datasets[xarray]",
   "pytest",
+  "pytest-skip-slow",
   "pytest-xdist",
 ]
 

--- a/tests/create/test_sources.py
+++ b/tests/create/test_sources.py
@@ -14,7 +14,6 @@ import numpy as np
 import pytest
 from anemoi.utils.testing import skip_if_offline
 from anemoi.utils.testing import skip_missing_packages
-from anemoi.utils.testing import skip_slow_tests
 
 from anemoi.datasets import open_dataset
 
@@ -212,7 +211,7 @@ def test_eccs_fstd(get_test_data: callable) -> None:
     assert ds.shape == (2, 2, 1, 162)
 
 
-@skip_slow_tests
+@pytest.mark.slow
 @skip_if_offline
 @skip_missing_packages("kerchunk", "s3fs")
 def test_kerchunk(get_test_data: callable) -> None:

--- a/tests/xarray/test_opendap.py
+++ b/tests/xarray/test_opendap.py
@@ -8,16 +8,16 @@
 # nor does it submit to any jurisdiction.
 
 
+import pytest
 import xarray as xr
 from anemoi.utils.testing import skip_if_offline
-from anemoi.utils.testing import skip_slow_tests
 
 from anemoi.datasets.create.sources.xarray import XarrayFieldList
 from anemoi.datasets.testing import assert_field_list
 
 
 @skip_if_offline
-@skip_slow_tests
+@pytest.mark.slow
 def test_opendap() -> None:
     """Test loading and validating the opendap dataset."""
     ds = xr.open_dataset(

--- a/tests/xarray/test_samples.py
+++ b/tests/xarray/test_samples.py
@@ -12,7 +12,6 @@ import pytest
 import requests
 import xarray as xr
 from anemoi.utils.testing import skip_if_offline
-from anemoi.utils.testing import skip_slow_tests
 
 from anemoi.datasets.create.sources.xarray import XarrayFieldList
 from anemoi.datasets.testing import assert_field_list
@@ -61,7 +60,7 @@ def _test_samples(n: int, check_skip: bool = True) -> None:
 
 
 @skip_if_offline
-@skip_slow_tests
+@pytest.mark.slow
 @pytest.mark.parametrize("n", SAMPLES)
 def test_samples(n: int) -> None:
     """Parametrized test for sample datasets.


### PR DESCRIPTION
## Description
This PR replaces the skip_slow_tests decorator with slow markers and the env var approach for the pytest cli (to not skip slow running tests) with an option --slow.

## What problem does this change solve?
Make markers and cli for slow tests consistent across the anemoi packages.

## What issue or task does this change relate to?
[<!-- link to Issue Number -->](https://github.com/ecmwf/anemoi-core/issues/257)

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
