### PR TITLE
feat: add 'model_level_number' to coordinate guesser (ecmwf/anemoi-datasets#402)

### DIFF
--- a/src/anemoi/datasets/create/sources/xarray_support/flavour.py
+++ b/src/anemoi/datasets/create/sources/xarray_support/flavour.py
@@ -759,6 +759,9 @@ class DefaultCoordinateGuesser(CoordinateGuesser):
         if attributes.standard_name == "atmosphere_hybrid_sigma_pressure_coordinate":
             return LevelCoordinate(c, "ml")
 
+        if attributes.standard_name == "model_level_number":
+            return LevelCoordinate(c, "ml")
+
         if attributes.long_name == "height" and attributes.units == "m":
             return LevelCoordinate(c, "height")
 

--- a/tests/xarray/test_flavour.py
+++ b/tests/xarray/test_flavour.py
@@ -84,6 +84,7 @@ def create_ds(var_name, standard_name, long_name, units, coord_length=5):
         ("vertical", "vertical", None, "hPa", LevelCoordinate),
         ("depth", "depth", None, "m", LevelCoordinate),
         ("depth", "depth", None, None, LevelCoordinate),
+        ("model_level_number", "model_level_number", None, None, LevelCoordinate),
         # number
         ("realization", None, None, None, EnsembleCoordinate),
         ("number", None, None, None, EnsembleCoordinate),


### PR DESCRIPTION
## Description
Adds a check for 'model_level_number' to `DefaultCoordinateGuesser._is_level()` and extends existing tests of this behaviour. 

## What problem does this change solve?
Anemoi datasets doesn't natively treat 'model_level_number' as a LevelCoordinate, and instead considers each model_level_number of a given field a duplicate entry. Extending the xarray coordinate guesser enables Anemoi-datasets to handle model_level_numbers as model levels natively. 

## What issue or task does this change relate to?
Closes #402.

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->
Follows a precedent set by #335.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
