### PR TITLE
chore: Speed up the tests with less parallelisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ profile = "black"
 testpaths = "tests"
 addopts = [
   "--numprocesses=auto",
+  "--maxprocesses=16",
   "--strict-config",
 ]
 


### PR DESCRIPTION
## Description
During the tests, ` "--numprocesses=auto",` gives a nice parallel run but when the number of processors is very large (on an HPC), the number of process is too large and the tests are actually slower.

Using the appropriate option solves the issue (see details here https://github.com/pytest-dev/pytest-xdist/issues/337 has a fix for this)

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
