### PR TITLE
fix: support for sources with already opened datasets

### DIFF
--- a/src/anemoi/datasets/create/sources/xarray_support/__init__.py
+++ b/src/anemoi/datasets/create/sources/xarray_support/__init__.py
@@ -93,7 +93,10 @@ def load_one(
         # If the dataset is a zarr store, we need to use the zarr engine
         options["engine"] = "zarr"
 
-    data = xr.open_dataset(dataset, **options)
+    if isinstance(dataset, xr.Dataset):
+        data = dataset
+    else:
+        data = xr.open_dataset(dataset, **options)
 
     fs = XarrayFieldList.from_xarray(data, flavour=flavour, patch=patch)
 


### PR DESCRIPTION
## Description

Fix a bug in xarray-based sources that open the array themselves.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
