### PR TITLE
fix: tendencies source context, metadata keys, dates

### DIFF
--- a/src/anemoi/datasets/create/sources/tendencies.py
+++ b/src/anemoi/datasets/create/sources/tendencies.py
@@ -16,6 +16,7 @@ from earthkit.data.readers.grib.output import new_grib_output
 
 from anemoi.datasets.create.sources import source_registry
 
+from ...dates.groups import GroupOfDates
 from .legacy import LegacySource
 
 
@@ -87,15 +88,15 @@ def group_by_field(ds: Any) -> dict[tuple, list[Any]]:
 class TendenciesSource(LegacySource):
 
     @staticmethod
-    def _execute(context: Any, dates: list[datetime.datetime], time_increment: Any, **kwargs: Any) -> Any:
+    def _execute(context: Any, dates: GroupOfDates, time_increment: Any, **kwargs: Any) -> Any:
         """Computes tendencies for the given dates and time increment.
 
         Parameters
         ----------
         context : Any
             The source context - passed through directly to the mars source.
-        dates : List[datetime.datetime]
-            A list of datetime objects.
+        dates : GroupOfDates
+            An object representing the dates for which to compute tendencies.
         time_increment : Any
             A time increment string ending with 'h' or a datetime.timedelta object.
         **kwargs : Any


### PR DESCRIPTION
## Description

Closes #451 

During https://github.com/ecmwf/anemoi-datasets/pull/430 and https://github.com/ecmwf/anemoi-datasets/pull/450, I noticed that the tendencies source has the wrong interface, i.e. all other sources accept a "context" as a first argument, whereas this source doesn't. This will also be a problem when it calls the mars source under the hood, which is also expecting a context but does not receive one. This PR adds the missing context, which is unused by the tendencies source directly, but is passed through directly to the mars source.

Additionally, I had to cast `dates` to a `list` as it was a `GroupOfDates`, and change some of the metadata checks due to updates in earthkit-data.

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
