### PR TITLE
fix: xarray-zarr filters

### DIFF
--- a/src/anemoi/datasets/create/sources/xarray_support/field.py
+++ b/src/anemoi/datasets/create/sources/xarray_support/field.py
@@ -121,16 +121,16 @@ class XArrayField(Field):
             Index to select a specific element, by default None.
         """
         if index is not None:
-            values = self.selection[index]
+            values = self.selection[index].values
         else:
-            values = self.selection
+            values = self.selection.values
 
         assert dtype is None
 
         if flatten:
-            return values.values.flatten()
+            return values.flatten()
 
-        return values.values
+        return values
 
     @cached_property
     def _metadata(self) -> XArrayMetadata:


### PR DESCRIPTION
## Description
The PR solves an issue where filters didn't work with xarray-zarr sources

## What problem does this change solve?
This is a bugfix for two issues:
- In `XArrayField.to_numpy()` with `flatten=True`, the output is `values.values.flatten()` but for `flatten=False` the output is only `values` where it should be `values.values` to actually get the numpy array.
- XArrayMetadata contains both 'variable' and 'param' so grouping by the metadata doesn't work because GroupByParam._get_groups only takes param into account by popping it and looking at the remaining metadata. If the remaining metadata matches then the params are grouped together. This doesn't work when variable is also there, because now the remaining metadata doesn't match


## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-datasets/issues/456

##  Additional notes ##

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
