### PR TITLE
docs: fix interpolate to interpolation key in combining page

### DIFF
--- a/docs/using/combining.rst
+++ b/docs/using/combining.rst
@@ -234,16 +234,16 @@ variables of `dataset1` and return the result.
        complement=dataset1,
        source=dataset2,
        what="variables",
-       interpolate="nearest",
+       interpolation="nearest",
        k=1,
    )
 
 Currently ``what`` can only be ``variables`` and can be omitted.
 
-The value for ``interpolate`` can be one of ``none`` (default) or
+The value for ``interpolation`` can be one of ``none`` (default) or
 ``nearest``. In the case of ``none``, the grids of the two datasets must
-match. In case of ``interpolate``, an additional parameter ``k`` can be
-set to specify the number of nearest neighbors to use.
+match. In case of ``interpolation``, an additional parameter ``k`` can
+be set to specify the number of nearest neighbors to use.
 
 This feature was originally designed to be used in conjunction with
 ``cutout``, where `dataset1` is the lam, and `dataset2` is the global


### PR DESCRIPTION
## Description
The `Combining datasets` page uses the key `interpolate` which should be `interpolation`.

## What problem does this change solve?
Doc inconsistency.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--461.org.readthedocs.build/en/461/

<!-- readthedocs-preview anemoi-datasets end -->