### PR TITLE
test: skip planetary_computer_conus404 test if APIError

### DIFF
--- a/tests/create/test_sources.py
+++ b/tests/create/test_sources.py
@@ -421,6 +421,7 @@ def test_kerchunk(get_test_data: callable) -> None:
 @skip_missing_packages("planetary_computer", "adlfs")
 def test_planetary_computer_conus404() -> None:
     """Test loading and validating the planetary_computer_conus404 dataset."""
+    import pystac_client
 
     config = {
         "dates": {
@@ -446,8 +447,10 @@ def test_planetary_computer_conus404() -> None:
             }
         },
     }
-
-    created = create_dataset(config=config, output=None)
+    try:
+        created = create_dataset(config=config, output=None)
+    except pystac_client.exceptions.APIError:
+        pytest.skip("Planetary Computer data catalog is not available")
     ds = open_dataset(created)
     assert ds.shape == (2, 1, 1, 1387505), ds.shape
 


### PR DESCRIPTION
Occasionally the planetary computer source fails due to a timeout. This skips the test if an APIError is raised to prevent the CI being marked as fail.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
