### PR TITLE
fix: pin min version of ruamel-yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "pytest>=8.4.1",
   "pytest-xdist>=3.7",
   "pyyaml",
-  "ruamel-yaml>=0.16.0",
+  "ruamel-yaml>=0.16",
   "semantic-version",
   "tqdm",
   "zarr<=2.18.4",


### PR DESCRIPTION
## Description
pins min version of ruamel-yaml to 0.16.0. This version was picked because it was the first version with a single generic wheel which supports all architectures and python versions. Previously there were individual wheels for specific configurations, if a matching configuration was not found then it would be built from source. (compare the number of wheels [here](https://pypi.org/project/ruamel.yaml/0.16.0/#files) vs [here](https://pypi.org/project/ruamel.yaml/0.15.100/#files))

During the anemoi-core integration tests, these builds of ruamel-yaml were failing, leading to the integration tests failing.