### PR TITLE
docs: correct typo of part to parts in incremental build #518

### DIFF
--- a/docs/building/incremental.rst
+++ b/docs/building/incremental.rst
@@ -25,7 +25,7 @@ the dataset, so it will not be needed by following commands.
    anemoi-datasets init dataset.yaml dataset.zarr --overwrite
 
 You can then load the dataset in parts with the `load` command. You just
-pass which part you want to load with the `--part` flag.
+pass which part you want to load with the `--parts` flag.
 
 .. note::
 
@@ -40,17 +40,17 @@ concurrent writes.
 
 .. code:: bash
 
-   anemoi-datasets load dataset.zarr --part 1/20
+   anemoi-datasets load dataset.zarr --parts 1/20
 
 .. code:: bash
 
-   anemoi-datasets load dataset.zarr --part 2/20
+   anemoi-datasets load dataset.zarr --parts 2/20
 
 ... and so on ... until:
 
 .. code:: bash
 
-   anemoi-datasets load dataset.zarr --part 20/20
+   anemoi-datasets load dataset.zarr --parts 20/20
 
 Once you have loaded all the parts, you can finalise the dataset with
 the `finalise` command. This will write the metadata and the attributes
@@ -87,8 +87,8 @@ To add statistics for 6h increments:
 .. code:: bash
 
    anemoi-datasets init-additions dataset.zarr --delta 6h
-   anemoi-datasets load-additions dataset.zarr --part 1/2 --delta 6h
-   anemoi-datasets load-additions dataset.zarr --part 2/2 --delta 6h
+   anemoi-datasets load-additions dataset.zarr --parts 1/2 --delta 6h
+   anemoi-datasets load-additions dataset.zarr --parts 2/2 --delta 6h
    anemoi-datasets finalise-additions dataset.zarr --delta 6h
 
 To add statistics for 12h increments:
@@ -96,8 +96,8 @@ To add statistics for 12h increments:
 .. code:: bash
 
    anemoi-datasets init-additions dataset.zarr --delta 12h
-   anemoi-datasets load-additions dataset.zarr --part 1/2 --delta 12h
-   anemoi-datasets load-additions dataset.zarr --part 2/2 --delta 12h
+   anemoi-datasets load-additions dataset.zarr --parts 1/2 --delta 12h
+   anemoi-datasets load-additions dataset.zarr --parts 2/2 --delta 12h
    anemoi-datasets finalise-additions dataset.zarr --delta 12h
 
 If this process leaves temporary files behind, you can clean them up


### PR DESCRIPTION
## Description
Corrects the typo identified in the incremental build docs where it refers to `--part` rather than `--parts`

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->
Doc update

## What issue or task does this change relate to?
<!-- link to Issue Number -->
#518 

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--519.org.readthedocs.build/en/519/

<!-- readthedocs-preview anemoi-datasets end -->