### PR TITLE
docs: explain option `allow_nans`

### DIFF
--- a/docs/building/handling-missing-values.rst
+++ b/docs/building/handling-missing-values.rst
@@ -18,3 +18,6 @@ Here's an example of how to implement it:
 
 .. literalinclude:: ../yaml/nan.yaml
    :language: yaml
+
+You can also set `allow_nans` to `true` to allow `NaNs` in any
+variable.


### PR DESCRIPTION
## Description
Just a bit more documentation.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--547.org.readthedocs.build/en/547/

<!-- readthedocs-preview anemoi-datasets end -->