### PR TITLE
docs: fix accumulation availability specification

### DIFF
--- a/docs/building/sources/accumulate.rst
+++ b/docs/building/sources/accumulate.rst
@@ -10,7 +10,7 @@
    - The parameter ``accumulation_period`` has been renamed to ``period``.
    - The source can be now different from ``mars`` (e.g., ``mars``, ``grib-index``)
      it must now be explicitly specified as a nested dictionary under the ``source`` key.
-   - The accumulation intervals must now be specified using the ``availability`` key.
+   - The available accumulation intervals must now be specified using the ``availability`` key.
 
 Accumulations and flux variables, such as precipitation, are often
 forecast fields, which are archived for a given base date (or reference


### PR DESCRIPTION
Tiny fix: `availability` was mistakenly marked as optional, when it is not

## Description
None

## What problem does this change solve?
Fixes incorrect documentation

## What issue or task does this change relate to?
None

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--551.org.readthedocs.build/en/551/

<!-- readthedocs-preview anemoi-datasets end -->