### PR TITLE
chore: add uv.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ docs/_api/
 .venv
 env/
 venv/
+uv.lock
 ENV/
 env.bak/
 venv.bak/


### PR DESCRIPTION
## Description

Exclude `uv.lock` from git history.

## What problem does this change solve?

Developers can install `anemoi-datasets` using `uv` via 

```
uv pip install ...
```

This generates a `uv.lock` file that shouldn't be tracked by git.

The use of `uv` should be anticipated given that it is already used elsewhere in the anemoi ecosystem, see e.g., https://github.com/ecmwf/anemoi-core/blob/c23cdab59a55551951addaebb9728239629157df/.github/workflows/python-pull-request.yml#L51

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
