### PR TITLE
fix: remove duplicate code

### DIFF
--- a/tests/create/test_create.py
+++ b/tests/create/test_create.py
@@ -44,22 +44,6 @@ for path in glob.glob(os.path.join(HERE, "*.yaml")):
             continue
     NAMES.append(name)
 
-IGNORE = ["recentre"]
-
-NAMES = []
-for path in glob.glob(os.path.join(HERE, "*.yaml")):
-    name, _ = os.path.splitext(os.path.basename(path))
-    if name in IGNORE:
-        continue
-    with open(path) as f:
-        conf = yaml.safe_load(f)
-        if conf.get("skip_test", False):
-            continue
-        if conf.get("slow_test", False):
-            NAMES.append(pytest.param(name, marks=pytest.mark.slow))
-            continue
-    NAMES.append(name)
-
 
 # Used by pipe.yaml
 @filter_registry.register("filter")


### PR DESCRIPTION
## Description

Remove duplicate code in tests that loops over yaml files in directory.

## What problem does this change solve?

Clearer code, remove redundancy.

##  Additional notes ##

Easily verified (if on main branch) with

```shell
# assuming in /path/to/anemoi-datasets
diff <(sed -n '31,45p' tests/create/test_create.py) <(sed -n '47,61p' tests/create/test_create.py)
```

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
