### PR TITLE
chore: change raise NotImplementedError to raise TypeError

### DIFF
--- a/src/anemoi/datasets/compat/zarr2.py
+++ b/src/anemoi/datasets/compat/zarr2.py
@@ -22,19 +22,19 @@ class _ReadOnlyStore(zarr.storage.BaseStore):
 
     def __delitem__(self, key: str) -> None:
         """Prevent deletion of items."""
-        raise NotImplementedError()
+        pass
 
     def __setitem__(self, key: str, value: bytes) -> None:
         """Prevent setting of items."""
-        raise NotImplementedError()
+        pass
 
     def __len__(self) -> int:
         """Return the number of items in the store."""
-        raise NotImplementedError()
+        pass
 
     def __iter__(self) -> iter:
         """Return an iterator over the store."""
-        raise NotImplementedError()
+        pass
 
 
 class HTTPStore(_ReadOnlyStore):

--- a/src/anemoi/datasets/compat/zarr2.py
+++ b/src/anemoi/datasets/compat/zarr2.py
@@ -21,12 +21,10 @@ class _ReadOnlyStore(zarr.storage.BaseStore):
     """A base class for read-only stores."""
 
     def __delitem__(self, key: str) -> None:
-        """Prevent deletion of items."""
-        pass
+        raise TypeError("Deleting items is not allowed")
 
     def __setitem__(self, key: str, value: bytes) -> None:
-        """Prevent setting of items."""
-        pass
+        raise TypeError("Setting items is not allowed")
 
     def __len__(self) -> int:
         """Return the number of items in the store."""

--- a/src/anemoi/datasets/compat/zarr2.py
+++ b/src/anemoi/datasets/compat/zarr2.py
@@ -30,11 +30,11 @@ class _ReadOnlyStore(zarr.storage.BaseStore):
 
     def __len__(self) -> int:
         """Return the number of items in the store."""
-        pass
+        raise NotImplementedError()
 
     def __iter__(self) -> iter:
         """Return an iterator over the store."""
-        pass
+        raise NotImplementedError()
 
 
 class HTTPStore(_ReadOnlyStore):


### PR DESCRIPTION
## Description

Per [python docs: built-in execptions#TypeError](https://docs.python.org/3/library/exceptions.html#TypeError), `TypeError`  should be used to indicate an operation is not supported. This PR replaces the `NotImplementedError`, which would imply one should implement the method, to `TypeError` to more clearly indicate the method is not meant to be implemented at all for children of the read-only class.

## What issue or task does this change relate to?

https://github.com/ecmwf/anemoi-datasets/issues/602

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
