### PR TITLE
chore: feature/zarr3 compatibility

### DIFF
--- a/src/anemoi/datasets/buffering.py
+++ b/src/anemoi/datasets/buffering.py
@@ -480,7 +480,7 @@ class ReadAheadWriteBehindBuffer:
 
     def __len__(self) -> int:
         """Return the number of elements in the underlying array."""
-        return len(self._arr)
+        return int(self._arr.shape[0])
 
     def resize(self, *new_shape: int) -> None:
         """Resize the underlying Zarr array and adjust cached chunks.
@@ -492,7 +492,7 @@ class ReadAheadWriteBehindBuffer:
         """
         with self._lock:
 
-            self._arr.resize(*new_shape)
+            self._arr.resize(new_shape)
 
             for chunk in list(self._lru_chunks_cache.values()):
                 chunk.resize(self._lru_chunks_cache, new_shape)

--- a/src/anemoi/datasets/buffering.py
+++ b/src/anemoi/datasets/buffering.py
@@ -488,8 +488,13 @@ class ReadAheadWriteBehindBuffer:
         Parameters
         ----------
         *new_shape : int
-            The new shape of the array.
+            The new shape of the array. Can be passed as
+            ``resize(a, b)`` or ``resize((a, b))``.
         """
+        # Normalise: accept both resize(a, b) and resize((a, b))
+        if len(new_shape) == 1 and isinstance(new_shape[0], (tuple, list)):
+            new_shape = tuple(new_shape[0])
+
         with self._lock:
 
             self._arr.resize(new_shape)

--- a/src/anemoi/datasets/compat/__init__.py
+++ b/src/anemoi/datasets/compat/__init__.py
@@ -19,6 +19,8 @@ if zarr_version < 3:
     from .zarr2 import S3Store
     from .zarr2 import ZarrFileNotFoundError
     from .zarr2 import zarr_append_mode
+
+    MemoryStore = zarr.storage.MemoryStore
 else:
     from .zarr3 import DebugStore
     from .zarr3 import HTTPStore
@@ -26,11 +28,14 @@ else:
     from .zarr3 import ZarrFileNotFoundError
     from .zarr3 import zarr_append_mode
 
+    MemoryStore = zarr.storage.MemoryStore
+
 __all__ = [
     "ZarrFileNotFoundError",
     "HTTPStore",
     "S3Store",
     "DebugStore",
+    "MemoryStore",
     "zarr_append_mode",
     "zarr_version",
     "zarr_private_files",

--- a/src/anemoi/datasets/create/dataset.py
+++ b/src/anemoi/datasets/create/dataset.py
@@ -142,7 +142,7 @@ class Dataset:
     ##################################
 
     def total_todo(self) -> int:
-        return len(self.store["_build"]["flags"])
+        return self.store["_build"]["flags"].shape[0]
 
     def todo_remaining(self) -> int:
         with self.synchronizer:

--- a/src/anemoi/datasets/create/sources/dop_zarr.py
+++ b/src/anemoi/datasets/create/sources/dop_zarr.py
@@ -81,7 +81,7 @@ class DOPZarrSource(Source):
                 self.dates = dates
 
             def __len__(self):
-                return len(self.dates)
+                return self.dates.shape[0]
 
             def __getitem__(self, value):
                 return self.dates[value][0]

--- a/src/anemoi/datasets/create/statistics.py
+++ b/src/anemoi/datasets/create/statistics.py
@@ -709,8 +709,8 @@ class StatisticsCollector:
 
             offset = state.end
 
-        if offset != len(dataset.data):
-            raise ValueError(f"Statistics end {offset} does not match dataset length {len(dataset.data)}")
+        if offset != dataset.data.shape[0]:
+            raise ValueError(f"Statistics end {offset} does not match dataset length {dataset.data.shape[0]}")
 
         # Adjust partial statistics
         for state in tqdm.tqdm(states, desc="Adjusting partial statistics", total=len(states)):

--- a/src/anemoi/datasets/date_indexing/btree.py
+++ b/src/anemoi/datasets/date_indexing/btree.py
@@ -269,7 +269,7 @@ class ZarrBTree:
 
         if self.number_of_rows >= self.pages.shape[0]:
             # Resize Zarr array to add more pages
-            self.pages.resize(self.pages.shape[0] + self.pages.chunks[0], self.pages.shape[1])
+            self.pages.resize((self.pages.shape[0] + self.pages.chunks[0], self.pages.shape[1]))
 
         new_row = self.number_of_rows
         self.number_of_rows += 1
@@ -835,7 +835,7 @@ class ZarrBTree:
 
         # Allocate all pages at once
         if total_pages > self.pages.shape[0]:
-            self.pages.resize(total_pages, cols_per_page)
+            self.pages.resize((total_pages, cols_per_page))
 
         # Build leaf pages starting after the existing root
         # If root is at page 1 (row 0), start at row 1

--- a/tests/test_chunks_cache_1.py
+++ b/tests/test_chunks_cache_1.py
@@ -5,7 +5,7 @@ from anemoi.datasets.buffering import ReadAheadWriteBehindBuffer
 
 
 def create_zarr_array(shape=(20, 3), chunks=(5, 3), dtype=np.int64):
-    store = zarr.MemoryStore()
+    store = zarr.storage.MemoryStore()
     arr = zarr.create(shape=shape, chunks=chunks, dtype=dtype, store=store, overwrite=True)
     arr[:] = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
     return arr

--- a/tests/test_chunks_cache_2.py
+++ b/tests/test_chunks_cache_2.py
@@ -28,7 +28,7 @@ def make_array():
     random = np.random.randint(-SIZE, SIZE, size=SHAPE, dtype=np.int32)
 
     array = zarr.open_array(
-        store=zarr.MemoryStore(),
+        store=zarr.storage.MemoryStore(),
         shape=data.shape,
         chunks=(1000, 10),
         dtype=data.dtype,


### PR DESCRIPTION
Update the anemoi-datasets code to keep being agnostic to the version of zarr.

- **fix resize and MemoryStore compatibility (zarr 2 and zarr 3 API are different)**
- **fix : zarr 3 removed len() on arrays**


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
