### PR TITLE
fix: propagate resolution metadata when using anemoi_dataset source

### DIFF
--- a/src/anemoi/datasets/create/gridded/result.py
+++ b/src/anemoi/datasets/create/gridded/result.py
@@ -594,6 +594,11 @@ class GriddedResult(Result):
 
         self._grid_points: Any = grid_points
         self._resolution: Any = first_field.resolution
+        if self._resolution is None:
+            try:
+                self._resolution = first_field.metadata().get("resolution")
+            except Exception:
+                pass
         self._grid_values: Any = grid_values
         self._field_shape: Any = first_field.shape
         self._proj_string: Any = first_field.proj_string if hasattr(first_field, "proj_string") else None

--- a/src/anemoi/datasets/create/sources/anemoi_dataset.py
+++ b/src/anemoi/datasets/create/sources/anemoi_dataset.py
@@ -45,10 +45,11 @@ class AnemoiDatasetSource(LegacySource):
         ensemble = ds.shape[2] > 1
         latitudes = ds.latitudes
         longitudes = ds.longitudes
+        resolution = ds.resolution
 
         for idx, date in indices:
 
-            metadata = dict(valid_datetime=date, latitudes=latitudes, longitudes=longitudes)
+            metadata = dict(valid_datetime=date, latitudes=latitudes, longitudes=longitudes, resolution=resolution)
 
             for j, y in enumerate(ds[idx]):
 


### PR DESCRIPTION
## Description
FIxes resolution metadata not being propagated when using `anemoi_dataset` as a source in `anemoi-datasets create`. 

## What problem does this change solve?
Bug fix, resolution is correctly propagated to new anemoi dataset built. 

Two changes:
- `create/sources/anemoi_dataset.py`: read `ds.resolution` and pass it into the field metadata dict alongside `latitudes` and `longitudes`
- `create/gridded/result.py`: add fallback — if `first_field.resolution is None`, try `first_field.metadata().get("resolution")`

## What issue or task does this change relate to?
Closes #613

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
