### PR TITLE
Fix: adapt name checking for non-gridded layout

### DIFF
--- a/docs/building/naming-conventions.rst
+++ b/docs/building/naming-conventions.rst
@@ -16,11 +16,19 @@ To ensure consistency, a dataset name should follow the following rules:
       other special characters (``@``, ``#``, ``*``, etc.).
 
 Additionally, a dataset name is built from different parts joined with
-``-`` as follows (each part can contain additional ``-``):
+``-`` as follows (each part can contain additional ``-``).  The exact
+form depends on the dataset's layout:
 
 .. code::
 
+   # Gridded layout (single date frequency)
    purpose-content-source-resolution-start-year-end-year-frequency-version[-extra-str]
+
+   # Trajectory layout (two frequencies: between base dates and between forecast steps)
+   purpose-content-source-resolution-start-year-end-year-date-frequency-step-frequency-version[-extra-str]
+
+   # Tabular layout (no frequency; resolution is optional)
+   purpose-content-source[-resolution]-start-year-end-year-version[-extra-str]
 
 .. note::
 
@@ -61,7 +69,13 @@ The tables below provide more details and some examples.
       -  mars (when data is from MARS), could be *opendap* or other.
 
    -  -  **resolution**
-      -  o96 (could be : n320, 0p2 for 0.2 degree)
+
+      -  o96 (could be : n320, 0p2 for 0.2 degree, 1km, 2km).  The
+         resolution token must start with a digit (``0``-``9``), ``o``
+         or ``n``.  It is **mandatory** for gridded and trajectory
+         layouts and **optional** for tabular layouts (since station
+         observation datasets often have no meaningful spatial
+         resolution).
 
    -  -  **start-year**
       -  1979 if the first validity time is in 1979.
@@ -74,7 +88,21 @@ The tables below provide more details and some examples.
          aifs-od-an-oper-0001-mars-o96-2020-2020-6h-v5
 
    -  -  **frequency**
-      -  1h (could be : 6h, 10m for 10 minutes)
+
+      -  1h (could be : 6h, 10m for 10 minutes).  The frequency token
+         is **mandatory** for gridded layouts and **absent** for
+         tabular layouts.
+
+   -  -  **date-frequency**, **step-frequency**
+
+      -  Trajectory datasets carry **two** frequencies, in this order:
+         the *date frequency* is the interval between consecutive base
+         dates (forecast initialisation times) and the *step frequency*
+         is the interval between consecutive forecast steps within one
+         trajectory.  For example
+         ``aifs-od-fc-oper-0001-mars-o96-2016-2025-18h-1h-v3`` describes
+         a trajectory dataset with one forecast every 18 h and hourly
+         steps within each forecast.
 
    -  -  **version**
 
@@ -90,7 +118,7 @@ The tables below provide more details and some examples.
          This extra string can contain additional `-`. It provides
          additional information about the content of the dataset.
 
-.. list-table:: Examples
+.. list-table:: Examples — gridded
    :widths: 100
 
    -  -  aifs-od-an-oper-0001-mars-o96-1979-2022-1h-v5
@@ -98,6 +126,19 @@ The tables below provide more details and some examples.
    -  -  aifs-ea-an-enda-0001-mars-o96-1979-2022-6h-v6-recentered-on-oper
    -  -  aifs-ea-an-oper-0001-mars-n320-1979-2022-6h-v4
    -  -  inca-an-oper-0001-gridefix-1km-2023-2024-10m-v1
+
+.. list-table:: Examples — trajectories
+   :widths: 100
+
+   -  -  aifs-od-fc-oper-0001-mars-o96-2016-2025-18h-1h-v3
+
+.. list-table:: Examples — tabular
+   :widths: 100
+
+   -  -  aifs-od-fc-oper-0001-mars-o96-2016-2025-v3
+   -  -  observations-ea-ofb-0001-1979-2023-v2-combined-aircraft-from-dop
+   -  -  dop-ea-ofb-0001-1979-2023-v2-combined-aircraft
+   -  -  dop-ea-ofb-0001-2km-1979-2023-v2-combined-aircraft
 
 `Anemoi Naming Conventions
 <https://anemoi-registry.readthedocs.io/en/latest/naming-conventions.html>`_

--- a/src/anemoi/datasets/create/naming.py
+++ b/src/anemoi/datasets/create/naming.py
@@ -25,10 +25,7 @@ LOG = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 # ``...-<purpose>-<labelling>-<source>-<resolution>-<start>-<end>-<freq>-v<n>[-extra]``
-GRIDDED_PATTERN = (
-    r"^(\w+)-([\w-]+)-(\w+)-([0-9on]\w*)-(\d\d\d\d)-(\d\d\d\d)-"
-    r"(\d+h|\d+m)-v(\d+)-?([a-zA-Z0-9-]+)?$"
-)
+GRIDDED_PATTERN = r"^(\w+)-([\w-]+)-(\w+)-([0-9on]\w*)-(\d\d\d\d)-(\d\d\d\d)-" r"(\d+h|\d+m)-v(\d+)-?([a-zA-Z0-9-]+)?$"
 GRIDDED_KEYS = [
     "purpose",
     "labelling",
@@ -43,8 +40,7 @@ GRIDDED_KEYS = [
 
 # ``...-<source>-<resolution>-<start>-<end>-<date-freq>-<step-freq>-v<n>[-extra]``
 TRAJECTORIES_PATTERN = (
-    r"^(\w+)-([\w-]+)-(\w+)-([0-9on]\w*)-(\d\d\d\d)-(\d\d\d\d)-"
-    r"(\d+h|\d+m)-(\d+h|\d+m)-v(\d+)-?([a-zA-Z0-9-]+)?$"
+    r"^(\w+)-([\w-]+)-(\w+)-([0-9on]\w*)-(\d\d\d\d)-(\d\d\d\d)-" r"(\d+h|\d+m)-(\d+h|\d+m)-v(\d+)-?([a-zA-Z0-9-]+)?$"
 )
 TRAJECTORIES_KEYS = [
     "purpose",
@@ -62,10 +58,7 @@ TRAJECTORIES_KEYS = [
 # ``...-<source>[-<resolution>]-<start>-<end>-v<n>[-extra]``
 # Resolution is optional: tabular datasets may have no meaningful spatial
 # resolution (e.g. station observations).
-TABULAR_PATTERN = (
-    r"^(\w+)-([\w-]+)-(\w+)(?:-([0-9on]\w*))?-(\d\d\d\d)-(\d\d\d\d)-"
-    r"v(\d+)-?([a-zA-Z0-9-]+)?$"
-)
+TABULAR_PATTERN = r"^(\w+)-([\w-]+)-(\w+)(?:-([0-9on]\w*))?-(\d\d\d\d)-(\d\d\d\d)-" r"v(\d+)-?([a-zA-Z0-9-]+)?$"
 TABULAR_KEYS = [
     "purpose",
     "labelling",

--- a/src/anemoi/datasets/create/naming.py
+++ b/src/anemoi/datasets/create/naming.py
@@ -18,6 +18,244 @@ from anemoi.utils.dates import frequency_to_string
 LOG = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Layout-specific patterns — one per layout, used for both validation and
+# layout-from-name inference.  Each pattern's groups are paired with the
+# matching ``*_KEYS`` list to build a parsed-fields dictionary.
+# ---------------------------------------------------------------------------
+
+# ``...-<purpose>-<labelling>-<source>-<resolution>-<start>-<end>-<freq>-v<n>[-extra]``
+GRIDDED_PATTERN = (
+    r"^(\w+)-([\w-]+)-(\w+)-([0-9on]\w*)-(\d\d\d\d)-(\d\d\d\d)-"
+    r"(\d+h|\d+m)-v(\d+)-?([a-zA-Z0-9-]+)?$"
+)
+GRIDDED_KEYS = [
+    "purpose",
+    "labelling",
+    "source",
+    "resolution",
+    "start_date",
+    "end_date",
+    "frequency",
+    "version",
+    "additional",
+]
+
+# ``...-<source>-<resolution>-<start>-<end>-<date-freq>-<step-freq>-v<n>[-extra]``
+TRAJECTORIES_PATTERN = (
+    r"^(\w+)-([\w-]+)-(\w+)-([0-9on]\w*)-(\d\d\d\d)-(\d\d\d\d)-"
+    r"(\d+h|\d+m)-(\d+h|\d+m)-v(\d+)-?([a-zA-Z0-9-]+)?$"
+)
+TRAJECTORIES_KEYS = [
+    "purpose",
+    "labelling",
+    "source",
+    "resolution",
+    "start_date",
+    "end_date",
+    "frequency",
+    "step_frequency",
+    "version",
+    "additional",
+]
+
+# ``...-<source>[-<resolution>]-<start>-<end>-v<n>[-extra]``
+# Resolution is optional: tabular datasets may have no meaningful spatial
+# resolution (e.g. station observations).
+TABULAR_PATTERN = (
+    r"^(\w+)-([\w-]+)-(\w+)(?:-([0-9on]\w*))?-(\d\d\d\d)-(\d\d\d\d)-"
+    r"v(\d+)-?([a-zA-Z0-9-]+)?$"
+)
+TABULAR_KEYS = [
+    "purpose",
+    "labelling",
+    "source",
+    "resolution",
+    "start_date",
+    "end_date",
+    "version",
+    "additional",
+]
+
+
+def guess_layout_from_name(name: str) -> str:
+    """Guess the dataset layout from the syntactic form of its name.
+
+    Returns ``"gridded"``, ``"trajectories"`` or ``"tabular"``.  Raises
+    :class:`ValueError` if the name does not follow any known convention.
+
+    Currently unused; provided for future call sites that need to recover
+    the layout from a dataset name without opening the dataset.
+
+    Parameters
+    ----------
+    name : str
+        The dataset name (without extension).
+    """
+    if re.match(GRIDDED_PATTERN, name):
+        return "gridded"
+    if re.match(TRAJECTORIES_PATTERN, name):
+        return "trajectories"
+    if re.match(TABULAR_PATTERN, name):
+        return "tabular"
+    raise ValueError(f"Cannot guess layout from name {name!r}; does not follow any known convention.")
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_characters(name: str) -> list[str]:
+    messages: list[str] = []
+    if not name.islower():
+        messages.append(f"The dataset name '{name}' should be in lower case.")
+    if "_" in name:
+        messages.append(f"The dataset name '{name}' should use '-' instead of '_'.")
+    for c in name:
+        if not c.isalnum() and c not in "-":
+            messages.append(f"The dataset name '{name}' should only contain alphanumeric characters and '-'.")
+    return messages
+
+
+def _check_resolution_match(parsed: dict, resolution: str | None, name: str) -> list[str]:
+    if resolution is None:
+        return []
+    messages: list[str] = []
+    resolution_str = str(resolution).replace(".", "p").lower()
+    if resolution_str not in name:
+        messages.append(f"The resolution is '{resolution_str}', but it is missing in '{name}'.")
+    if parsed.get("resolution") and parsed["resolution"] != resolution_str:
+        messages.append(f"The resolution is '{resolution_str}', but it is '{parsed['resolution']}' in '{name}'.")
+    return messages
+
+
+def _check_frequency_match(
+    parsed: dict, frequency: datetime.timedelta | None, key: str, label: str, name: str
+) -> list[str]:
+    if frequency is None:
+        return []
+    messages: list[str] = []
+    frequency_str = frequency_to_string(frequency)
+    if frequency_str not in name:
+        messages.append(f"The {label} is '{frequency_str}', but it is missing in '{name}'.")
+    if parsed.get(key) and parsed[key] != frequency_str:
+        messages.append(f"The {label} is '{frequency_str}', but it is '{parsed[key]}' in '{name}'.")
+    return messages
+
+
+def _check_year_match(parsed: dict, year_date: datetime.date | None, key: str, label: str, name: str) -> list[str]:
+    if year_date is None:
+        return []
+    messages: list[str] = []
+    year_str = str(year_date.year)
+    if year_str not in name:
+        messages.append(f"The {label} is '{year_str}', but it is missing in '{name}'.")
+    if parsed.get(key) and parsed[key] != year_str:
+        messages.append(f"The {label} is '{year_str}', but it is '{parsed[key]}' in '{name}'.")
+    return messages
+
+
+def _layout_mismatch_diagnostic(name: str, requested_layout: str) -> list[str]:
+    """Diagnose why ``name`` failed the requested layout's regex.
+
+    If the name follows another known convention, point the user at the
+    matching layout.  Otherwise return a generic-non-conformant message.
+    """
+    try:
+        actual = guess_layout_from_name(name)
+    except ValueError:
+        return [
+            f"The dataset name '{name}' does not follow any known naming convention. "
+            "See here for details: "
+            "https://anemoi-registry.readthedocs.io/en/latest/naming-conventions.html"
+        ]
+    return [
+        f"The dataset name '{name}' follows the {actual} naming convention, "
+        f"but the requested layout is {requested_layout}."
+    ]
+
+
+def _format_parsed(name: str, parsed: dict) -> str:
+    return f"'{name}' is parsed as: " + "/".join(f"{k}={v}" for k, v in parsed.items()) + "."
+
+
+# ---------------------------------------------------------------------------
+# Per-layout validators
+# ---------------------------------------------------------------------------
+
+
+def _check_gridded_name(
+    name: str,
+    resolution: str | None,
+    start_date: datetime.date | None,
+    end_date: datetime.date | None,
+    frequency: datetime.timedelta | None,
+) -> list[str]:
+    messages = _check_characters(name)
+    match = re.match(GRIDDED_PATTERN, name)
+    if not match:
+        messages.extend(_layout_mismatch_diagnostic(name, "gridded"))
+        return messages
+    parsed = dict(zip(GRIDDED_KEYS, match.groups()))
+    messages.extend(_check_resolution_match(parsed, resolution, name))
+    messages.extend(_check_frequency_match(parsed, frequency, "frequency", "frequency", name))
+    messages.extend(_check_year_match(parsed, start_date, "start_date", "start date", name))
+    messages.extend(_check_year_match(parsed, end_date, "end_date", "end date", name))
+    if messages:
+        messages.append(_format_parsed(name, parsed))
+    return messages
+
+
+def _check_trajectories_name(
+    name: str,
+    resolution: str | None,
+    start_date: datetime.date | None,
+    end_date: datetime.date | None,
+    frequency: datetime.timedelta | None,
+    step_frequency: datetime.timedelta | None,
+) -> list[str]:
+    messages = _check_characters(name)
+    match = re.match(TRAJECTORIES_PATTERN, name)
+    if not match:
+        messages.extend(_layout_mismatch_diagnostic(name, "trajectories"))
+        return messages
+    parsed = dict(zip(TRAJECTORIES_KEYS, match.groups()))
+    messages.extend(_check_resolution_match(parsed, resolution, name))
+    messages.extend(_check_frequency_match(parsed, frequency, "frequency", "frequency", name))
+    messages.extend(_check_frequency_match(parsed, step_frequency, "step_frequency", "step frequency", name))
+    messages.extend(_check_year_match(parsed, start_date, "start_date", "start date", name))
+    messages.extend(_check_year_match(parsed, end_date, "end_date", "end date", name))
+    if messages:
+        messages.append(_format_parsed(name, parsed))
+    return messages
+
+
+def _check_tabular_name(
+    name: str,
+    resolution: str | None,
+    start_date: datetime.date | None,
+    end_date: datetime.date | None,
+) -> list[str]:
+    messages = _check_characters(name)
+    match = re.match(TABULAR_PATTERN, name)
+    if not match:
+        messages.extend(_layout_mismatch_diagnostic(name, "tabular"))
+        return messages
+    parsed = dict(zip(TABULAR_KEYS, match.groups()))
+    messages.extend(_check_resolution_match(parsed, resolution, name))
+    messages.extend(_check_year_match(parsed, start_date, "start_date", "start date", name))
+    messages.extend(_check_year_match(parsed, end_date, "end_date", "end date", name))
+    if messages:
+        messages.append(_format_parsed(name, parsed))
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
 def check_dataset_name(
     name: str,
     resolution: str | None = None,
@@ -29,52 +267,56 @@ def check_dataset_name(
 ) -> list[str]:
     """Check if a dataset name follows the naming conventions.
 
-    Three layout-dependent forms are recognised:
+    Three layout-dependent forms are recognised, each with its own regex:
 
-    - Single-frequency form (``layout="gridded"``):
-      ``...-<start-year>-<end-year>-<freq>-v<n>[-extra]``,
-      e.g. ``aifs-od-an-oper-0001-mars-o96-1979-2022-1h-v5``.
-    - Two-frequency form (``layout="trajectories"``):
-      ``...-<start-year>-<end-year>-<date-freq>-<step-freq>-v<n>[-extra]``,
-      e.g. ``aifs-od-fc-oper-0001-mars-o96-2016-2025-18h-1h-v3``.
-    - No-frequency form (``layout="tabular"``):
-      ``...-<start-year>-<end-year>-v<n>[-extra]``,
-      e.g. ``aifs-od-fc-oper-0001-mars-o96-2016-2025-v3``.
+    - ``layout="gridded"``      → ``...-<source>-<resolution>-<start>-<end>-<freq>-v<n>[-extra]``
+      (e.g. ``aifs-od-an-oper-0001-mars-o96-1979-2022-1h-v5``).
+    - ``layout="trajectories"`` → ``...-<source>-<resolution>-<start>-<end>-<date-freq>-<step-freq>-v<n>[-extra]``
+      (e.g. ``aifs-od-fc-oper-0001-mars-o96-2016-2025-18h-1h-v3``).
+    - ``layout="tabular"``      → ``...-<source>[-<resolution>]-<start>-<end>-v<n>[-extra]``
+      (e.g. ``aifs-od-fc-oper-0001-mars-o96-2016-2025-v3`` or
+      ``dop-ea-ofb-0001-1979-2023-v2-combined-aircraft``).
 
-    Each call site passes its ``layout`` explicitly. The validator rejects
-    names whose frequency count does not match the layout (e.g. a gridded
-    layout name with two frequencies, or a tabular layout name with one).
+    The resolution token is mandatory for ``gridded`` and ``trajectories``
+    and optional for ``tabular`` (which often has no meaningful spatial
+    resolution — e.g. station observations).
 
-    The ``layout`` argument is required to validate against the tabular
-    no-frequency form: tabular dataset names are not the silent default,
-    they must be opted into. For backward compatibility, when ``layout``
-    is omitted it is inferred from the frequency arguments:
-    ``step_frequency`` set → ``trajectories``; otherwise ``gridded``.
+    The function dispatches on ``layout`` to one of three layout-specific
+    validators (``_check_gridded_name`` / ``_check_trajectories_name`` /
+    ``_check_tabular_name``).  When a name does not match the requested
+    layout's regex, the diagnostic checks whether it follows another
+    convention (via :func:`guess_layout_from_name`) and reports
+    accordingly.
+
+    Tabular is never inferred — callers must opt in via ``layout="tabular"``,
+    so a missing or typo'd ``frequency`` argument from another caller is
+    not silently classified as a tabular name.  For backward compatibility,
+    when ``layout`` is omitted it is inferred as ``trajectories`` if
+    ``step_frequency`` is set, otherwise ``gridded``.
 
     Parameters
     ----------
     name : str
-        The name of the dataset.
-    resolution : Optional[str], optional
-        The expected resolution of the dataset.
-    start_date : Optional[datetime.date], optional
-        The expected start date of the dataset.
-    end_date : Optional[datetime.date], optional
-        The expected end date of the dataset.
-    frequency : Optional[datetime.timedelta], optional
-        The expected frequency of the dataset (date frequency for gridded
-        layouts, base-date frequency for trajectory layouts). Not used for
-        tabular layouts.
-    step_frequency : Optional[datetime.timedelta], optional
-        The expected step frequency. Only meaningful for trajectory layouts.
-    layout : Optional[str], optional
-        ``"gridded"``, ``"trajectories"``, or ``"tabular"``. When ``None``,
+        The dataset name.
+    resolution : str, optional
+        Expected resolution.
+    start_date : datetime.date, optional
+        Expected start date (only the year is checked).
+    end_date : datetime.date, optional
+        Expected end date.
+    frequency : datetime.timedelta, optional
+        Expected frequency (date frequency for gridded layouts, base-date
+        frequency for trajectory layouts).  Not used for tabular layouts.
+    step_frequency : datetime.timedelta, optional
+        Expected step frequency.  Only used for trajectory layouts.
+    layout : str, optional
+        ``"gridded"``, ``"trajectories"``, or ``"tabular"``.  When ``None``,
         inferred from the frequency arguments (see above).
 
     Returns
     -------
-    list[str]
-        A list of error messages, or an empty list if the name is valid.
+    list of str
+        Validation messages, empty when the name is conformant.
     """
     config = load_config().get("datasets", {})
     if config.get("ignore_naming_conventions", False):
@@ -84,116 +326,10 @@ def check_dataset_name(
         # Tabular is never inferred — callers must opt in explicitly.
         layout = "trajectories" if step_frequency is not None else "gridded"
 
-    if layout not in ("gridded", "trajectories", "tabular"):
-        raise ValueError(f"Unknown layout {layout!r}; expected 'gridded', 'trajectories' or 'tabular'.")
-
-    messages = []
-
-    # check_characters
-    if not name.islower():
-        messages.append(f"The dataset name '{name}' should be in lower case.")
-    if "_" in name:
-        messages.append(f"The dataset name '{name}' should use '-' instead of '_'.")
-    for c in name:
-        if not c.isalnum() and c not in "-":
-            messages.append(f"The dataset name '{name}' should only contain alphanumeric characters and '-'.")
-
-    # parse — both frequency slots are optional so the same regex matches
-    # the no-frequency (tabular), single-frequency (gridded), and
-    # two-frequency (trajectories) forms.  The number of captured frequency
-    # tokens is then validated against the expected layout.
-    pattern = (
-        r"^(\w+)-([\w-]+)-(\w+)-(\w+)-(\d\d\d\d)-(\d\d\d\d)"
-        r"(?:-(\d+h|\d+m))?(?:-(\d+h|\d+m))?-v(\d+)-?([a-zA-Z0-9-]+)?$"
-    )
-    match = re.match(pattern, name)
-    parsed = {}
-    if match:
-        keys = [
-            "purpose",
-            "labelling",
-            "source",
-            "resolution",
-            "start_date",
-            "end_date",
-            "frequency",
-            "step_frequency",
-            "version",
-            "additional",
-        ]
-        parsed = {k: v for k, v in zip(keys, match.groups())}
-
-    # check_parsed
-    if not parsed:
-        messages.append(
-            f"The dataset name '{name}' does not follow the naming convention. "
-            "See here for details: "
-            "https://anemoi-registry.readthedocs.io/en/latest/naming-conventions.html"
-        )
-
-    # check layout / form coherence
-    n_freqs = sum(1 for k in ("frequency", "step_frequency") if parsed.get(k) is not None)
-    expected_n_freqs = {"tabular": 0, "gridded": 1, "trajectories": 2}[layout]
-    if parsed and n_freqs != expected_n_freqs:
-        forms = {
-            0: "no-frequency form '-v<n>'",
-            1: "single-frequency form '-<freq>-v<n>'",
-            2: "two-frequency form '-<date-freq>-<step-freq>-v<n>'",
-        }
-        observed = forms[n_freqs]
-        expected = forms[expected_n_freqs]
-        messages.append(
-            f"The dataset name '{name}' uses the {observed}, but {layout} "
-            f"layouts require the {expected}."
-        )
-
-    # check_resolution
-    if parsed.get("resolution") and parsed["resolution"][0] not in "0123456789on":
-        messages.append(
-            f"The resolution '{parsed['resolution']}' should start "
-            f"with a number, 'o', or 'n' in the dataset name '{name}'."
-        )
-    if resolution is not None:
-        resolution_str = str(resolution).replace(".", "p").lower()
-        if resolution_str not in name:
-            messages.append(f"The resolution is '{resolution_str}', but it is missing in '{name}'.")
-        if parsed.get("resolution") and parsed["resolution"] != resolution_str:
-            messages.append(f"The resolution is '{resolution_str}', but it is '{parsed['resolution']}' in '{name}'.")
-
-    # check_frequency
-    if frequency is not None:
-        frequency_str = frequency_to_string(frequency)
-        if frequency_str not in name:
-            messages.append(f"The frequency is '{frequency_str}', but it is missing in '{name}'.")
-        if parsed.get("frequency") and parsed["frequency"] != frequency_str:
-            messages.append(f"The frequency is '{frequency_str}', but it is '{parsed['frequency']}' in '{name}'.")
-
-    # check_step_frequency (trajectory layouts only)
-    if step_frequency is not None:
-        step_frequency_str = frequency_to_string(step_frequency)
-        if parsed.get("step_frequency") and parsed["step_frequency"] != step_frequency_str:
-            messages.append(
-                f"The step frequency is '{step_frequency_str}', but it is "
-                f"'{parsed['step_frequency']}' in '{name}'."
-            )
-
-    # check_start_date
-    if start_date is not None:
-        start_date_str = str(start_date.year)
-        if start_date_str not in name:
-            messages.append(f"The start date is '{start_date_str}', but it is missing in '{name}'.")
-        if parsed.get("start_date") and parsed["start_date"] != start_date_str:
-            messages.append(f"The start date is '{start_date_str}', but it is '{parsed['start_date']}' in '{name}'.")
-
-    # check_end_date
-    if end_date is not None:
-        end_date_str = str(end_date.year)
-        if end_date_str not in name:
-            messages.append(f"The end date is '{end_date_str}', but it is missing in '{name}'.")
-        if parsed.get("end_date") and parsed["end_date"] != end_date_str:
-            messages.append(f"The end date is '{end_date_str}', but it is '{parsed['end_date']}' in '{name}'.")
-
-    if messages:
-        messages.append(f"'{name}' is parsed as: " + "/".join(f"{k}={v}" for k, v in parsed.items()) + ".")
-
-    return messages
+    if layout == "gridded":
+        return _check_gridded_name(name, resolution, start_date, end_date, frequency)
+    if layout == "trajectories":
+        return _check_trajectories_name(name, resolution, start_date, end_date, frequency, step_frequency)
+    if layout == "tabular":
+        return _check_tabular_name(name, resolution, start_date, end_date)
+    raise ValueError(f"Unknown layout {layout!r}; expected 'gridded', 'trajectories' or 'tabular'.")

--- a/src/anemoi/datasets/create/naming.py
+++ b/src/anemoi/datasets/create/naming.py
@@ -24,8 +24,32 @@ def check_dataset_name(
     start_date: datetime.date | None = None,
     end_date: datetime.date | None = None,
     frequency: datetime.timedelta | None = None,
+    step_frequency: datetime.timedelta | None = None,
+    layout: str | None = None,
 ) -> list[str]:
     """Check if a dataset name follows the naming conventions.
+
+    Three layout-dependent forms are recognised:
+
+    - Single-frequency form (``layout="gridded"``):
+      ``...-<start-year>-<end-year>-<freq>-v<n>[-extra]``,
+      e.g. ``aifs-od-an-oper-0001-mars-o96-1979-2022-1h-v5``.
+    - Two-frequency form (``layout="trajectories"``):
+      ``...-<start-year>-<end-year>-<date-freq>-<step-freq>-v<n>[-extra]``,
+      e.g. ``aifs-od-fc-oper-0001-mars-o96-2016-2025-18h-1h-v3``.
+    - No-frequency form (``layout="tabular"``):
+      ``...-<start-year>-<end-year>-v<n>[-extra]``,
+      e.g. ``aifs-od-fc-oper-0001-mars-o96-2016-2025-v3``.
+
+    Each call site passes its ``layout`` explicitly. The validator rejects
+    names whose frequency count does not match the layout (e.g. a gridded
+    layout name with two frequencies, or a tabular layout name with one).
+
+    The ``layout`` argument is required to validate against the tabular
+    no-frequency form: tabular dataset names are not the silent default,
+    they must be opted into. For backward compatibility, when ``layout``
+    is omitted it is inferred from the frequency arguments:
+    ``step_frequency`` set → ``trajectories``; otherwise ``gridded``.
 
     Parameters
     ----------
@@ -38,7 +62,14 @@ def check_dataset_name(
     end_date : Optional[datetime.date], optional
         The expected end date of the dataset.
     frequency : Optional[datetime.timedelta], optional
-        The expected frequency of the dataset.
+        The expected frequency of the dataset (date frequency for gridded
+        layouts, base-date frequency for trajectory layouts). Not used for
+        tabular layouts.
+    step_frequency : Optional[datetime.timedelta], optional
+        The expected step frequency. Only meaningful for trajectory layouts.
+    layout : Optional[str], optional
+        ``"gridded"``, ``"trajectories"``, or ``"tabular"``. When ``None``,
+        inferred from the frequency arguments (see above).
 
     Returns
     -------
@@ -48,6 +79,13 @@ def check_dataset_name(
     config = load_config().get("datasets", {})
     if config.get("ignore_naming_conventions", False):
         return []
+
+    if layout is None:
+        # Tabular is never inferred — callers must opt in explicitly.
+        layout = "trajectories" if step_frequency is not None else "gridded"
+
+    if layout not in ("gridded", "trajectories", "tabular"):
+        raise ValueError(f"Unknown layout {layout!r}; expected 'gridded', 'trajectories' or 'tabular'.")
 
     messages = []
 
@@ -60,8 +98,14 @@ def check_dataset_name(
         if not c.isalnum() and c not in "-":
             messages.append(f"The dataset name '{name}' should only contain alphanumeric characters and '-'.")
 
-    # parse
-    pattern = r"^(\w+)-([\w-]+)-(\w+)-(\w+)-(\d\d\d\d)-(\d\d\d\d)-(\d+h|\d+m)-v(\d+)-?([a-zA-Z0-9-]+)?$"
+    # parse — both frequency slots are optional so the same regex matches
+    # the no-frequency (tabular), single-frequency (gridded), and
+    # two-frequency (trajectories) forms.  The number of captured frequency
+    # tokens is then validated against the expected layout.
+    pattern = (
+        r"^(\w+)-([\w-]+)-(\w+)-(\w+)-(\d\d\d\d)-(\d\d\d\d)"
+        r"(?:-(\d+h|\d+m))?(?:-(\d+h|\d+m))?-v(\d+)-?([a-zA-Z0-9-]+)?$"
+    )
     match = re.match(pattern, name)
     parsed = {}
     if match:
@@ -73,6 +117,7 @@ def check_dataset_name(
             "start_date",
             "end_date",
             "frequency",
+            "step_frequency",
             "version",
             "additional",
         ]
@@ -84,6 +129,22 @@ def check_dataset_name(
             f"The dataset name '{name}' does not follow the naming convention. "
             "See here for details: "
             "https://anemoi-registry.readthedocs.io/en/latest/naming-conventions.html"
+        )
+
+    # check layout / form coherence
+    n_freqs = sum(1 for k in ("frequency", "step_frequency") if parsed.get(k) is not None)
+    expected_n_freqs = {"tabular": 0, "gridded": 1, "trajectories": 2}[layout]
+    if parsed and n_freqs != expected_n_freqs:
+        forms = {
+            0: "no-frequency form '-v<n>'",
+            1: "single-frequency form '-<freq>-v<n>'",
+            2: "two-frequency form '-<date-freq>-<step-freq>-v<n>'",
+        }
+        observed = forms[n_freqs]
+        expected = forms[expected_n_freqs]
+        messages.append(
+            f"The dataset name '{name}' uses the {observed}, but {layout} "
+            f"layouts require the {expected}."
         )
 
     # check_resolution
@@ -106,6 +167,15 @@ def check_dataset_name(
             messages.append(f"The frequency is '{frequency_str}', but it is missing in '{name}'.")
         if parsed.get("frequency") and parsed["frequency"] != frequency_str:
             messages.append(f"The frequency is '{frequency_str}', but it is '{parsed['frequency']}' in '{name}'.")
+
+    # check_step_frequency (trajectory layouts only)
+    if step_frequency is not None:
+        step_frequency_str = frequency_to_string(step_frequency)
+        if parsed.get("step_frequency") and parsed["step_frequency"] != step_frequency_str:
+            messages.append(
+                f"The step frequency is '{step_frequency_str}', but it is "
+                f"'{parsed['step_frequency']}' in '{name}'."
+            )
 
     # check_start_date
     if start_date is not None:

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,152 @@
+# (C) Copyright 2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Tests for ``anemoi.datasets.create.naming.check_dataset_name``.
+
+Three layout-dependent forms are recognised:
+
+- ``layout="gridded"``      → ``...-<start>-<end>-<freq>-v<n>[-extra]``.
+- ``layout="trajectories"`` → ``...-<start>-<end>-<date-freq>-<step-freq>-v<n>[-extra]``.
+- ``layout="tabular"``      → ``...-<start>-<end>-v<n>[-extra]``.
+
+The validator must accept each form when called with the matching layout
+and reject every other combination. Tabular is never inferred — callers
+must opt in explicitly.
+"""
+
+import datetime
+
+
+class TestCheckDatasetName:
+    """Cover all three layout-dependent naming forms."""
+
+    GRIDDED_NAME = "aifs-od-an-oper-0001-mars-o96-1979-2022-1h-v5"
+    TRAJECTORY_NAME = "aifs-od-fc-oper-0001-mars-o96-2016-2025-18h-1h-v3"
+    TABULAR_NAME = "aifs-od-fc-oper-0001-mars-o96-2016-2025-v3"
+
+    def _check(self, name, **kwargs):
+        from anemoi.datasets.create.naming import check_dataset_name
+
+        return check_dataset_name(name, **kwargs)
+
+    # -- match cases ------------------------------------------------------
+
+    def test_trajectory_name_with_trajectory_call_passes(self):
+        msgs = self._check(
+            self.TRAJECTORY_NAME,
+            layout="trajectories",
+            resolution="o96",
+            start_date=datetime.date(2016, 1, 1),
+            end_date=datetime.date(2025, 1, 1),
+            frequency=datetime.timedelta(hours=18),
+            step_frequency=datetime.timedelta(hours=1),
+        )
+        assert msgs == []
+
+    def test_gridded_name_with_gridded_call_passes(self):
+        msgs = self._check(
+            self.GRIDDED_NAME,
+            layout="gridded",
+            resolution="o96",
+            start_date=datetime.date(1979, 1, 1),
+            end_date=datetime.date(2022, 1, 1),
+            frequency=datetime.timedelta(hours=1),
+        )
+        assert msgs == []
+
+    def test_tabular_name_with_tabular_call_passes(self):
+        msgs = self._check(
+            self.TABULAR_NAME,
+            layout="tabular",
+            start_date=datetime.date(2016, 1, 1),
+            end_date=datetime.date(2025, 1, 1),
+        )
+        assert msgs == []
+
+    # -- cross-layout mismatches -----------------------------------------
+
+    def test_trajectory_name_with_gridded_call_warns(self):
+        msgs = self._check(self.TRAJECTORY_NAME, layout="gridded")
+        assert any("two-frequency form" in m and "gridded" in m for m in msgs)
+
+    def test_trajectory_name_with_tabular_call_warns(self):
+        msgs = self._check(self.TRAJECTORY_NAME, layout="tabular")
+        assert any("two-frequency form" in m and "tabular" in m for m in msgs)
+
+    def test_gridded_name_with_trajectory_call_warns(self):
+        msgs = self._check(
+            self.GRIDDED_NAME,
+            layout="trajectories",
+            step_frequency=datetime.timedelta(hours=1),
+        )
+        assert any("single-frequency form" in m and "trajectories" in m for m in msgs)
+
+    def test_gridded_name_with_tabular_call_warns(self):
+        msgs = self._check(self.GRIDDED_NAME, layout="tabular")
+        assert any("single-frequency form" in m and "tabular" in m for m in msgs)
+
+    def test_tabular_name_with_gridded_call_warns(self):
+        msgs = self._check(self.TABULAR_NAME, layout="gridded")
+        assert any("no-frequency form" in m and "gridded" in m for m in msgs)
+
+    def test_tabular_name_with_trajectory_call_warns(self):
+        msgs = self._check(
+            self.TABULAR_NAME,
+            layout="trajectories",
+            step_frequency=datetime.timedelta(hours=1),
+        )
+        assert any("no-frequency form" in m and "trajectories" in m for m in msgs)
+
+    # -- frequency-value mismatches --------------------------------------
+
+    def test_trajectory_step_frequency_mismatch_warns(self):
+        msgs = self._check(
+            self.TRAJECTORY_NAME,
+            layout="trajectories",
+            frequency=datetime.timedelta(hours=18),
+            step_frequency=datetime.timedelta(hours=6),
+        )
+        assert any("step frequency" in m and "1h" in m for m in msgs)
+
+    # -- extra suffix -----------------------------------------------------
+
+    def test_trajectory_with_extra_suffix_passes(self):
+        msgs = self._check(
+            self.TRAJECTORY_NAME + "-experimental",
+            layout="trajectories",
+            frequency=datetime.timedelta(hours=18),
+            step_frequency=datetime.timedelta(hours=1),
+        )
+        assert msgs == []
+
+    def test_tabular_with_extra_suffix_passes(self):
+        msgs = self._check(self.TABULAR_NAME + "-experimental", layout="tabular")
+        assert msgs == []
+
+    # -- backward-compat layout inference --------------------------------
+
+    def test_layout_inferred_from_kwargs(self):
+        # No layout kwarg; the validator must infer "gridded" or "trajectories"
+        # from frequency / step_frequency.  Tabular is never inferred —
+        # callers must pass layout="tabular" explicitly.
+        assert self._check(self.GRIDDED_NAME, frequency=datetime.timedelta(hours=1)) == []
+        assert (
+            self._check(
+                self.TRAJECTORY_NAME,
+                frequency=datetime.timedelta(hours=18),
+                step_frequency=datetime.timedelta(hours=1),
+            )
+            == []
+        )
+
+    def test_tabular_is_never_default(self):
+        # Without layout="tabular", a tabular-shaped name must be flagged
+        # as gridded-non-conformant rather than silently accepted.
+        msgs = self._check(self.TABULAR_NAME)
+        assert any("no-frequency form" in m and "gridded" in m for m in msgs)

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -70,14 +70,16 @@ class TestCheckDatasetName:
         assert msgs == []
 
     # -- cross-layout mismatches -----------------------------------------
+    # When the requested layout doesn't match, the diagnostic identifies
+    # the convention the name actually follows (via guess_layout_from_name).
 
     def test_trajectory_name_with_gridded_call_warns(self):
         msgs = self._check(self.TRAJECTORY_NAME, layout="gridded")
-        assert any("two-frequency form" in m and "gridded" in m for m in msgs)
+        assert any("trajectories naming convention" in m and "gridded" in m for m in msgs)
 
     def test_trajectory_name_with_tabular_call_warns(self):
         msgs = self._check(self.TRAJECTORY_NAME, layout="tabular")
-        assert any("two-frequency form" in m and "tabular" in m for m in msgs)
+        assert any("trajectories naming convention" in m and "tabular" in m for m in msgs)
 
     def test_gridded_name_with_trajectory_call_warns(self):
         msgs = self._check(
@@ -85,15 +87,15 @@ class TestCheckDatasetName:
             layout="trajectories",
             step_frequency=datetime.timedelta(hours=1),
         )
-        assert any("single-frequency form" in m and "trajectories" in m for m in msgs)
+        assert any("gridded naming convention" in m and "trajectories" in m for m in msgs)
 
     def test_gridded_name_with_tabular_call_warns(self):
         msgs = self._check(self.GRIDDED_NAME, layout="tabular")
-        assert any("single-frequency form" in m and "tabular" in m for m in msgs)
+        assert any("gridded naming convention" in m and "tabular" in m for m in msgs)
 
     def test_tabular_name_with_gridded_call_warns(self):
         msgs = self._check(self.TABULAR_NAME, layout="gridded")
-        assert any("no-frequency form" in m and "gridded" in m for m in msgs)
+        assert any("tabular naming convention" in m and "gridded" in m for m in msgs)
 
     def test_tabular_name_with_trajectory_call_warns(self):
         msgs = self._check(
@@ -101,7 +103,7 @@ class TestCheckDatasetName:
             layout="trajectories",
             step_frequency=datetime.timedelta(hours=1),
         )
-        assert any("no-frequency form" in m and "trajectories" in m for m in msgs)
+        assert any("tabular naming convention" in m and "trajectories" in m for m in msgs)
 
     # -- frequency-value mismatches --------------------------------------
 
@@ -149,4 +151,89 @@ class TestCheckDatasetName:
         # Without layout="tabular", a tabular-shaped name must be flagged
         # as gridded-non-conformant rather than silently accepted.
         msgs = self._check(self.TABULAR_NAME)
-        assert any("no-frequency form" in m and "gridded" in m for m in msgs)
+        assert any("tabular naming convention" in m and "gridded" in m for m in msgs)
+
+    # -- optional resolution (tabular only) ------------------------------
+
+    def test_tabular_without_resolution_passes(self):
+        # Tabular datasets often lack a meaningful spatial resolution
+        # (e.g. station observations).  The resolution token is optional
+        # for tabular only.
+        msgs = self._check("aifs-od-fc-oper-0001-mars-2016-2025-v3", layout="tabular")
+        assert msgs == []
+
+    def test_tabular_observations_real_name_passes(self):
+        msgs = self._check(
+            "observations-ea-ofb-0001-1979-2023-v2-combined-aircraft-from-dop",
+            layout="tabular",
+        )
+        assert msgs == []
+
+    def test_tabular_dop_real_name_passes(self):
+        msgs = self._check(
+            "dop-ea-ofb-0001-1979-2023-v2-combined-aircraft",
+            layout="tabular",
+        )
+        assert msgs == []
+
+    def test_tabular_dop_with_o96_resolution_passes(self):
+        msgs = self._check(
+            "dop-ea-ofb-0001-o96-1979-2023-v2-combined-aircraft",
+            layout="tabular",
+        )
+        assert msgs == []
+
+    def test_tabular_dop_with_2km_resolution_passes(self):
+        # ``2km``-style resolutions are explicitly supported (starts with a digit).
+        msgs = self._check(
+            "dop-ea-ofb-0001-2km-1979-2023-v2-combined-aircraft",
+            layout="tabular",
+        )
+        assert msgs == []
+
+    def test_gridded_without_resolution_warns(self):
+        # Resolution is mandatory for gridded layouts; a name lacking the
+        # resolution token does not match the gridded regex (and does not
+        # match any other layout's regex either, since it still has a
+        # frequency token).
+        msgs = self._check(
+            "aifs-od-an-oper-0001-mars-1979-2022-1h-v5",
+            layout="gridded",
+        )
+        assert any("does not follow any known naming convention" in m for m in msgs)
+
+    def test_trajectories_without_resolution_warns(self):
+        # Resolution is mandatory for trajectory layouts.
+        msgs = self._check(
+            "aifs-od-fc-oper-0001-mars-2016-2025-18h-1h-v3",
+            layout="trajectories",
+            step_frequency=datetime.timedelta(hours=1),
+        )
+        assert any("does not follow any known naming convention" in m for m in msgs)
+
+
+class TestGuessLayoutFromName:
+    """Cover the public ``guess_layout_from_name`` helper."""
+
+    def _guess(self, name):
+        from anemoi.datasets.create.naming import guess_layout_from_name
+
+        return guess_layout_from_name(name)
+
+    def test_gridded(self):
+        assert self._guess("aifs-od-an-oper-0001-mars-o96-1979-2022-1h-v5") == "gridded"
+
+    def test_trajectories(self):
+        assert self._guess("aifs-od-fc-oper-0001-mars-o96-2016-2025-18h-1h-v3") == "trajectories"
+
+    def test_tabular_with_resolution(self):
+        assert self._guess("aifs-od-fc-oper-0001-mars-o96-2016-2025-v3") == "tabular"
+
+    def test_tabular_without_resolution(self):
+        assert self._guess("dop-ea-ofb-0001-1979-2023-v2-combined-aircraft") == "tabular"
+
+    def test_unknown_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="Cannot guess layout"):
+            self._guess("not-a-valid-dataset-name")


### PR DESCRIPTION
## Description
 anemoi-datasets create writes a LOG.warning when the dataset path doesn't follow the registry naming convention. The current validator only knows the gridded form. This adds two more layout-dependent forms.

https://anemoi--629.org.readthedocs.build/projects/datasets/en/629/building/naming-conventions.html


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--629.org.readthedocs.build/en/629/

<!-- readthedocs-preview anemoi-datasets end -->