### PR TITLE
feat: export json schema

### DIFF
--- a/docs/cli/introduction.rst
+++ b/docs/cli/introduction.rst
@@ -22,6 +22,7 @@ The commands are:
 - :ref:`Scan Command <scan_command>`
 - :ref:`Validate Command <validate_command>`
 - :ref:`Compare LAM Command <compare_lam_command>`
+- :ref:`Schema Command <schema_command>`
 
 
 
@@ -40,3 +41,4 @@ The commands are:
    cli/patch
    cli/compare-lam
    cli/validate
+   cli/schema

--- a/docs/cli/schema.rst
+++ b/docs/cli/schema.rst
@@ -1,0 +1,17 @@
+.. _schema_command:
+
+Schema Command
+==============
+
+The `schema` command exports the JSON schema of a recipe. This can be useful for validating
+recipe files or for integrating with tools that support JSON schema.
+
+.. code:: console
+
+   $ anemoi-datasets schema
+
+.. argparse::
+    :module: anemoi.datasets.__main__
+    :func: create_parser
+    :prog: anemoi-datasets
+    :path: schema

--- a/src/anemoi/datasets/commands/schema.py
+++ b/src/anemoi/datasets/commands/schema.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024 Anemoi contributors.
+# (C) Copyright 2026 Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/src/anemoi/datasets/commands/schema.py
+++ b/src/anemoi/datasets/commands/schema.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 
 
 class Schema(Command):
-    """Export the JSON schema of a recipe"""
+    """Export the JSON schema of the recipe"""
 
     timestamp = False
 

--- a/src/anemoi/datasets/commands/schema.py
+++ b/src/anemoi/datasets/commands/schema.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import logging
+from typing import Any
+
+from . import Command
+
+LOG = logging.getLogger(__name__)
+
+
+class Schema(Command):
+    """Export the JSON schema of a recipe"""
+
+    timestamp = False
+
+    def add_arguments(self, command_parser: Any) -> None:
+        """Add arguments to the command parser.
+
+        Parameters
+        ----------
+        command_parser : Any
+            The command parser.
+        """
+        pass
+
+    def run(self, args: Any) -> None:
+        import json
+
+        from anemoi.datasets.create.recipe import Recipe
+
+        print(json.dumps(Recipe.model_json_schema(), indent=2))
+
+
+command = Schema


### PR DESCRIPTION
## Description

Add the command `anemoi-datasets schema` to export the JSON schema of a dataset recipe. Useful for validation tools or IDE such as vscode, that will use it to autocomplete and highlight errors. 

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--630.org.readthedocs.build/en/630/

<!-- readthedocs-preview anemoi-datasets end -->