### PR TITLE
fix: Inspect failure when dataset is not finalised

### DIFF
--- a/src/anemoi/datasets/commands/inspect.py
+++ b/src/anemoi/datasets/commands/inspect.py
@@ -406,7 +406,7 @@ class Version:
         try:
             self.dataset.statistics
             return True
-        except AttributeError:
+        except KeyError:
             return False
 
     @property
@@ -462,9 +462,9 @@ class Version:
             )
             return
 
-        build_flags = self.build_flags or np.array([], dtype=bool)
+        build_flags = np.array([], dtype=bool) if self.build_flags is None else self.build_flags
 
-        build_lengths = self.build_lengths or np.array([], dtype=bool)
+        build_lengths = np.array([], dtype=bool) if self.build_lengths is None else self.build_lengths
         assert build_flags.size == build_lengths.size
 
         latest_write_timestamp = self.zarr.attrs.get("latest_write_timestamp")


### PR DESCRIPTION
## Description
Running anemoi-datasets inspect fails on a dataset that hasn't been finished yet. The same happens when the dataset is partially complete.

## What problem does this change solve?
This change solves the problem

## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-datasets/issues/647

##  Additional notes ##

I believe there are two problems:
1) Firstly, commit ab8cd717 changed self.dataset.statistics to be a dictionary, which can now throw a KeyError when the dataset is not finalised. `statistics_ready` does not catch this anymore since it's expecting an AttributeError.

2) `build_flags = self.build_flags or np.array([], dtype=bool)` doesn't work anymore since self.build_flags is now a numpy array.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
