### PR TITLE
feat: sanitise recipe for catalogue

### DIFF
--- a/src/anemoi/datasets/commands/compare.py
+++ b/src/anemoi/datasets/commands/compare.py
@@ -259,10 +259,14 @@ def _compare_dot_zattrs(errors, reference: dict, actual: dict, *path) -> None:
         # references created before this change keep matching.
         "metadata.order_by",
         "metadata.recipe.output.order_by",
+        # ``recipe_expanded`` is derived metadata (a copy/expansion of ``recipe``);
+        # ignore it so datasets built before it existed keep matching.
+        "metadata.recipe_expanded",
     ]
 
     IGNORE_MISSINGS = [
         "metadata.history",
+        "metadata.recipe_expanded",
         "metadata.recipe.dates.group_by",
         "metadata.recipe.output.statistics",
         "metadata.recipe.output.flatten_grid",

--- a/src/anemoi/datasets/commands/inspect.py
+++ b/src/anemoi/datasets/commands/inspect.py
@@ -34,6 +34,26 @@ from . import Command
 LOG = logging.getLogger(__name__)
 
 
+def _recipe_drift_keys(a: Any, b: Any, prefix: str = "") -> list[str]:
+    """Return dotted paths where ``a`` and ``b`` differ.
+
+    Used to compare a recipe rebuilt with the current schema defaults against the
+    stored full recipe, to detect fields whose default has changed.
+    """
+    if isinstance(a, dict) and isinstance(b, dict):
+        keys: list[str] = []
+        for k in set(a) | set(b):
+            sub = f"{prefix}.{k}" if prefix else str(k)
+            if k not in a or k not in b:
+                keys.append(sub)
+            else:
+                keys.extend(_recipe_drift_keys(a[k], b[k], sub))
+        return keys
+    if a != b:
+        return [prefix or "<root>"]
+    return []
+
+
 def compute_directory_size(path: str) -> tuple[int, int] | tuple[None, None]:
     """Compute the total size and number of files in a directory.
 
@@ -553,12 +573,42 @@ class Version:
         import yaml
 
         z = open_zarr_store(path)
+
+        self._warn_recipe_default_drift(z)
+
         for name in ("_create_yaml_config", "_recipe", "recipe"):
             if name in z.attrs:
                 print(yaml.safe_dump(z.attrs[name], sort_keys=False))
                 return
 
         print("No recipe found in the dataset.")
+
+    def _warn_recipe_default_drift(self, z: Any) -> None:
+        """Warn if the schema defaults changed since the dataset was built.
+
+        The slimmed ``recipe`` attribute omits every field equal to its schema
+        default at build time, while ``recipe_expanded`` keeps them. If a default has
+        changed since, reconstructing the recipe from the slim ``recipe`` would
+        now yield different values than ``recipe_expanded``.
+        """
+        if "recipe" not in z.attrs or "recipe_expanded" not in z.attrs:
+            return
+
+        try:
+            from anemoi.datasets.create.recipe import Recipe
+
+            rebuilt = Recipe(**z.attrs["recipe"]).model_dump(mode="json")
+        except Exception:
+            # Cannot revalidate (e.g. sanitised paths) -- skip silently.
+            return
+
+        drift = sorted(_recipe_drift_keys(rebuilt, z.attrs["recipe_expanded"]))
+        if drift:
+            LOG.warning(
+                "Schema defaults changed since this dataset was built; the slimmed "
+                "'recipe' now differs from 'recipe_expanded' at: %s",
+                ", ".join(drift),
+            )
 
 
 class NoVersion(Version):

--- a/src/anemoi/datasets/commands/inspect.py
+++ b/src/anemoi/datasets/commands/inspect.py
@@ -598,8 +598,8 @@ class Version:
             from anemoi.datasets.create.recipe import Recipe
 
             rebuilt = Recipe(**z.attrs["recipe"]).model_dump(mode="json")
-        except Exception:
-            # Cannot revalidate (e.g. sanitised paths) -- skip silently.
+        except Exception as e:
+            LOG.warning("Could not expand 'recipe' to check it against 'recipe_expanded': %s", e)
             return
 
         drift = sorted(_recipe_drift_keys(rebuilt, z.attrs["recipe_expanded"]))

--- a/src/anemoi/datasets/create/creator.py
+++ b/src/anemoi/datasets/create/creator.py
@@ -7,7 +7,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import json
 import logging
 import os
 import shutil
@@ -182,13 +181,24 @@ class Creator(ABC):
         # This entry will be deleted when the dataset is finalised
         # We use model_dump_json to have a JSON string, because Zarr sorts attrs keys
 
-        model_dump = self.recipe.model_dump_json()
-        metadata["_recipe"] = model_dump
+        metadata["_recipe"] = self.recipe.model_dump_json()
 
-        # Store a sanitised (no path, no urls,...) version of the recipe for the catalogue
-        # This one will be kept in the finalised dataset metadata
+        # Store a sanitised (no path, no urls,...) full version of the recipe, kept in the
+        # finalised dataset metadata for reproducibility. Unlike the catalogue ``recipe``
+        # below, this keeps fields that are equal to their schema default.
 
-        model_dump = json.loads(model_dump)
+        full_dump = self.recipe.model_dump(mode="json")
+        full_dump = self.recipe.strip_unknown_keys(full_dump)
+        if self.recipe.output.sanitise:
+            metadata["recipe_expanded"] = sanitise(full_dump)
+        else:
+            metadata["recipe_expanded"] = full_dump
+
+        # Store a sanitised, slimmed-down version of the recipe for the catalogue.
+        # ``exclude_defaults`` drops every field equal to its schema default so the
+        # catalogue only shows what the user actually set.
+
+        model_dump = self.recipe.model_dump(mode="json", exclude_defaults=True)
         model_dump = self.recipe.strip_unknown_keys(model_dump)
         if self.recipe.output.sanitise:
             recipe = sanitise(model_dump)

--- a/src/anemoi/datasets/create/creator.py
+++ b/src/anemoi/datasets/create/creator.py
@@ -287,7 +287,16 @@ class Creator(ABC):
     ######################################################
 
     def task_patch(self) -> None:
-        pass
+        # Backfill ``recipe_expanded`` for datasets built before it existed.
+        # The old ``recipe`` attribute already holds the full (non-slimmed) recipe,
+        # so we copy it across verbatim rather than rebuilding it.
+        dataset = Dataset(self.path, update=True)
+        if dataset.get_metadata("recipe_expanded") is None and dataset.get_metadata("recipe") is not None:
+            dataset.update_metadata(recipe_expanded=dataset.get_metadata("recipe"))
+            dataset.touch()
+            LOG.info("Backfilled 'recipe_expanded' from 'recipe'.")
+        else:
+            LOG.info("Nothing to patch: 'recipe_expanded' already present or no 'recipe'.")
 
     def task_size(self) -> None:
         dataset = Dataset(self.path, update=True)


### PR DESCRIPTION
Add in the metadata`recipe_expanded` with the recipe expanded with default, while the `recipe` in the metadata contain the recipe without the default. Both are still sanitised to hide potentially private file paths and passwords. 
No change in anemoi-datasets behaviour.

## Description
<!-- What issue or task does this change relate to? -->

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
