### PR TITLE
fix: trajectory metadata

### DIFF
--- a/src/anemoi/datasets/usage/trajectories/store.py
+++ b/src/anemoi/datasets/usage/trajectories/store.py
@@ -280,7 +280,7 @@ class TrajectoriesZarr(ZarrStore):
             variables=self.variables,
             shape=self.shape,
             base_frequency=frequency_to_string(self.base_frequency),
-            step_frequency=frequency_to_string(step_freq) if step_freq is not None else None,
+            step_frequency=frequency_to_string(step_freq),
             start_date=str(self.start_date),
             end_date=str(self.end_date),
             base_start_date=str(self.base_start_date),

--- a/src/anemoi/datasets/usage/trajectories/store.py
+++ b/src/anemoi/datasets/usage/trajectories/store.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import numpy as np
 import zarr
+from anemoi.utils.dates import frequency_to_string
 from anemoi.utils.dates import frequency_to_timedelta
 from numpy.typing import NDArray
 
@@ -264,6 +265,28 @@ class TrajectoriesZarr(ZarrStore):
     def resolution(self) -> str | None:
         """Return the grid resolution string."""
         return self.store.attrs.get("resolution")
+
+    def metadata_specific(self, **kwargs: Any) -> dict[str, Any]:
+        """Return trajectory-specific metadata.
+
+        Overrides :meth:`Dataset.metadata_specific` to avoid calling
+        ``self.frequency``, which raises for trajectory datasets because
+        they have two frequencies (``base_frequency`` and ``step_frequency``).
+        """
+        action = self.__class__.__name__.lower()
+        step_freq = self.step_frequency
+        return dict(
+            action=action,
+            variables=self.variables,
+            shape=self.shape,
+            base_frequency=frequency_to_string(self.base_frequency),
+            step_frequency=frequency_to_string(step_freq) if step_freq is not None else None,
+            start_date=str(self.start_date),
+            end_date=str(self.end_date),
+            base_start_date=str(self.base_start_date),
+            base_end_date=str(self.base_end_date),
+            **kwargs,
+        )
 
     def dataset_metadata(self) -> dict[str, Any]:
         """Return dataset metadata using trajectory-compatible properties."""

--- a/src/anemoi/datasets/usage/trajectories/subset.py
+++ b/src/anemoi/datasets/usage/trajectories/subset.py
@@ -111,7 +111,7 @@ class StepSubset(Forwards):
             variables=self.variables,
             shape=self.shape,
             base_frequency=frequency_to_string(self.base_frequency),
-            step_frequency=frequency_to_string(step_freq) if step_freq is not None else None,
+            step_frequency=frequency_to_string(step_freq),
             start_date=str(self.start_date),
             end_date=str(self.end_date),
             base_start_date=str(self.base_start_date),

--- a/src/anemoi/datasets/usage/trajectories/subset.py
+++ b/src/anemoi/datasets/usage/trajectories/subset.py
@@ -374,7 +374,7 @@ class Subset(Forwards):
             variables=self.variables,
             shape=self.shape,
             base_frequency=frequency_to_string(self.base_frequency),
-            step_frequency=frequency_to_string(step_freq) if step_freq is not None else None,
+            step_frequency=frequency_to_string(step_freq),
             start_date=str(self.start_date),
             end_date=str(self.end_date),
             base_start_date=str(self.base_start_date),

--- a/src/anemoi/datasets/usage/trajectories/subset.py
+++ b/src/anemoi/datasets/usage/trajectories/subset.py
@@ -17,6 +17,7 @@ from typing import Any
 from typing import Union
 
 import numpy as np
+from anemoi.utils.dates import frequency_to_string
 from anemoi.utils.dates import frequency_to_timedelta
 from numpy.typing import NDArray
 
@@ -101,6 +102,42 @@ class StepSubset(Forwards):
     def forwards_subclass_metadata_specific(self) -> dict[str, Any]:
         return {"step_indices": self.step_indices}
 
+    def metadata_specific(self, **kwargs: Any) -> dict[str, Any]:
+        """Override to avoid calling self.frequency (trajectory datasets have two frequencies)."""
+        action = self.__class__.__name__.lower()
+        step_freq = self.step_frequency
+        return dict(
+            action=action,
+            variables=self.variables,
+            shape=self.shape,
+            base_frequency=frequency_to_string(self.base_frequency),
+            step_frequency=frequency_to_string(step_freq) if step_freq is not None else None,
+            start_date=str(self.start_date),
+            end_date=str(self.end_date),
+            base_start_date=str(self.base_start_date),
+            base_end_date=str(self.base_end_date),
+            forward=self.forward.metadata_specific(),
+            **self.forwards_subclass_metadata_specific(),
+            **kwargs,
+        )
+
+    def dataset_metadata(self) -> dict[str, Any]:
+        """Override to avoid calling self.frequency (trajectory datasets have two frequencies)."""
+        return dict(
+            specific=self.metadata_specific(),
+            base_frequency=self.base_frequency,
+            step_frequency=self.step_frequency,
+            variables=self.variables,
+            variables_metadata=self.variables_metadata,
+            shape=self.shape,
+            dtype=str(self.dtype),
+            start_date=str(self.start_date),
+            end_date=str(self.end_date),
+            base_start_date=str(self.base_start_date),
+            base_end_date=str(self.base_end_date),
+            name=self.name,
+        )
+
     def tree(self) -> Node:
         return Node(self, [self.forward.tree()])
 
@@ -141,6 +178,38 @@ class SingleStepView(Forwards):
 
     def forwards_subclass_metadata_specific(self) -> dict[str, Any]:
         return {"step_index": self.step_index}
+
+    def metadata_specific(self, **kwargs: Any) -> dict[str, Any]:
+        """Override to avoid calling self.frequency (trajectory datasets have two frequencies)."""
+        action = self.__class__.__name__.lower()
+        step_freq = self.forward.step_frequency
+        return dict(
+            action=action,
+            variables=self.variables,
+            shape=self.shape,
+            base_frequency=frequency_to_string(self.forward.base_frequency),
+            step_frequency=frequency_to_string(step_freq) if step_freq is not None else None,
+            start_date=str(self.start_date),
+            end_date=str(self.end_date),
+            forward=self.forward.metadata_specific(),
+            **self.forwards_subclass_metadata_specific(),
+            **kwargs,
+        )
+
+    def dataset_metadata(self) -> dict[str, Any]:
+        """Override to avoid calling self.frequency (trajectory datasets have two frequencies)."""
+        return dict(
+            specific=self.metadata_specific(),
+            base_frequency=self.forward.base_frequency,
+            step_frequency=self.forward.step_frequency,
+            variables=self.variables,
+            variables_metadata=self.variables_metadata,
+            shape=self.shape,
+            dtype=str(self.dtype),
+            start_date=str(self.start_date),
+            end_date=str(self.end_date),
+            name=self.name,
+        )
 
     def tree(self) -> Node:
         return Node(self, [self.forward.tree()])
@@ -295,3 +364,39 @@ class Subset(Forwards):
 
     def forwards_subclass_metadata_specific(self) -> dict[str, Any]:
         return {"indices": self.indices, "reason": self.reason}
+
+    def metadata_specific(self, **kwargs: Any) -> dict[str, Any]:
+        """Override to avoid calling self.frequency (trajectory datasets have two frequencies)."""
+        action = self.__class__.__name__.lower()
+        step_freq = self.step_frequency
+        return dict(
+            action=action,
+            variables=self.variables,
+            shape=self.shape,
+            base_frequency=frequency_to_string(self.base_frequency),
+            step_frequency=frequency_to_string(step_freq) if step_freq is not None else None,
+            start_date=str(self.start_date),
+            end_date=str(self.end_date),
+            base_start_date=str(self.base_start_date),
+            base_end_date=str(self.base_end_date),
+            forward=self.forward.metadata_specific(),
+            **self.forwards_subclass_metadata_specific(),
+            **kwargs,
+        )
+
+    def dataset_metadata(self) -> dict[str, Any]:
+        """Override to avoid calling self.frequency (trajectory datasets have two frequencies)."""
+        return dict(
+            specific=self.metadata_specific(),
+            base_frequency=self.base_frequency,
+            step_frequency=self.step_frequency,
+            variables=self.variables,
+            variables_metadata=self.variables_metadata,
+            shape=self.shape,
+            dtype=str(self.dtype),
+            start_date=str(self.start_date),
+            end_date=str(self.end_date),
+            base_start_date=str(self.base_start_date),
+            base_end_date=str(self.base_end_date),
+            name=self.name,
+        )

--- a/src/anemoi/datasets/usage/trajectories/subset.py
+++ b/src/anemoi/datasets/usage/trajectories/subset.py
@@ -188,7 +188,7 @@ class SingleStepView(Forwards):
             variables=self.variables,
             shape=self.shape,
             base_frequency=frequency_to_string(self.forward.base_frequency),
-            step_frequency=frequency_to_string(step_freq) if step_freq is not None else None,
+            step_frequency=frequency_to_string(step_freq),
             start_date=str(self.start_date),
             end_date=str(self.end_date),
             forward=self.forward.metadata_specific(),

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -299,6 +299,37 @@ class TestTrajectoriesZarr:
         item = self.ds[0:2]
         assert item.shape == (2, 3, 1, 5, 10)
 
+    # ------------------------------------------------------------------
+    # metadata / metadata_specific — regression for AttributeError on
+    # .frequency (trajectories have two frequencies, not one).
+    # ------------------------------------------------------------------
+
+    def test_frequency_raises(self):
+        """Accessing .frequency must raise AttributeError (by design)."""
+        with pytest.raises(AttributeError, match="two frequencies"):
+            _ = self.ds.frequency
+
+    def test_metadata_specific_does_not_call_frequency(self):
+        """metadata_specific() must succeed and not touch .frequency."""
+        md = self.ds.metadata_specific()
+        assert "base_frequency" in md
+        assert "step_frequency" in md
+        assert "frequency" not in md  # the broken single-frequency key must be absent
+        assert md["action"] == "trajectorieszarr"
+
+    def test_dataset_metadata_does_not_call_frequency(self):
+        """dataset_metadata() must succeed without raising AttributeError."""
+        md = self.ds.dataset_metadata()
+        assert "base_frequency" in md
+        assert "step_frequency" in md
+        assert "specific" in md
+
+    def test_metadata_does_not_call_frequency(self):
+        """The top-level metadata() call must succeed end-to-end."""
+        md = self.ds.metadata()
+        assert "base_frequency" in md
+        assert "step_frequency" in md
+
 
 # ---------------------------------------------------------------------------
 # StepSubset


### PR DESCRIPTION
## Description
The metadata for the trajectory datasets does not currently work with anemoi core because the metadata assumes `frequency` which is not present in the trajectory datasets


##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
