### PR TITLE
fix: support old datasets

### DIFF
--- a/src/anemoi/datasets/usage/forwards.py
+++ b/src/anemoi/datasets/usage/forwards.py
@@ -350,9 +350,9 @@ class Combined(Forwards):
         ValueError
             If the resolutions are not the same.
         """
-        # if d1.resolution is None or d2.resolution is None:
-        #     LOG.warning("One of the datasets has no resolution, cannot check compatibility")
-        #     return
+        if d1.resolution is None or d2.resolution is None:
+            LOG.warning("One of the datasets has no resolution, cannot check compatibility")
+            return
 
         if d1.resolution != d2.resolution:
             raise ValueError(
@@ -486,7 +486,14 @@ class Combined(Forwards):
         """
         from anemoi.transform.variables import Variable
 
-        Variable.check_compatibility(d1.typed_variables, d2.typed_variables)
+        tv1 = d1.typed_variables
+        tv2 = d2.typed_variables
+
+        if not tv1 or not tv2:
+            LOG.warning("One of the datasets has no variable metadata, cannot check compatibility")
+            return
+
+        Variable.check_compatibility(tv1, tv2)
 
     def check_same_lengths(self, d1: Dataset, d2: Dataset) -> None:
         """Checks if the lengths of two datasets are the same.

--- a/src/anemoi/datasets/usage/gridded/store.py
+++ b/src/anemoi/datasets/usage/gridded/store.py
@@ -150,9 +150,9 @@ class GriddedZarr(ZarrStore):
         )
 
     @property
-    def resolution(self) -> str:
+    def resolution(self) -> str | None:
         """Return the resolution of the dataset."""
-        return self.store.attrs["resolution"]
+        return self.store.attrs.get("resolution")
 
     @property
     def field_shape(self) -> tuple:


### PR DESCRIPTION
Users reported breaking changes on "some of the older datasets we commonly use, which are missing resolution (or have resolution=None), and/or missing variable_metadata."

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those, please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
