### PR TITLE
feat: add missing dependency, psutil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
   "numcodecs<0.16",        # Until we move to zarr3
   "numpy",
   "pint",
+  "psutil",
   "pydantic",
   "pyodc>=1.6",
   "pyyaml",


### PR DESCRIPTION
This  add missing dependency, psutil

used here: anemoi-datasets/src/anemoi/datasets/create/tabular/finalise.py:import psutil


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
