### PR TITLE
chore: pin earthkit < 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,9 +69,9 @@ optional-dependencies.comparelam = [
 ]
 optional-dependencies.create = [
   "cachetools",
-  "earthkit-data[mars]>=0.14",
-  "earthkit-geo>=0.3",
-  "earthkit-meteo>=0.3",
+  "earthkit-data[mars]>=0.14,<1",
+  "earthkit-geo>=0.3,<1",
+  "earthkit-meteo>=0.3,<1",
   "eccodes>=2.39.1",
   "entrypoints",
   "fasteners",


### PR DESCRIPTION
## Description
Earthkit 1.0 will be released shortly. To prevent fresh installs of anemoi-datasets breaking before we have had chance to upgrade - we need to pin the dependencies.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
