### PR TITLE
fix: Release rolling average assumption.

### DIFF
--- a/src/anemoi/datasets/usage/gridded/rolling_average.py
+++ b/src/anemoi/datasets/usage/gridded/rolling_average.py
@@ -55,7 +55,7 @@ class RollingAverage(Forwards):
         # window = (0, 0, 'freq') means no change
         self.i_start = -window[0]
         self.i_end = window[1] + 1
-        if self.i_start <= 0:
+        if self.i_start < 0:
             raise ValueError(f"Window start must be negative, got {window}")
         if self.i_end <= 0:
             raise ValueError(f"Window end must be positive, got {window}")


### PR DESCRIPTION
## Description
Allow forward-looking rolling-average windows by relaxing the window-start validation in RollingAverage.

Previously the constructor required the window start to be strictly negative (`self.i_start <= 0` → error), forcing every rolling average to include at least one look-back step. This rejected legitimate forward-only windows such as `rolling_average: [0, 4, 'frequency']` (average over the current step plus the next 4), which fail with:
```
ValueError: Window start must be negative, got [0, 4, 'frequency']
```
The check is relaxed from `< = 0` to `< 0`, so a window start of 0 (start = current step) is accepted, while a genuinely invalid positive start (window beginning in the future) is still rejected. 

## What issue or task does this change relate to?


## Additional notes
- Positive starts (future-only windows) remain rejected.
- The `(0, 0, 'freq')` "no change" case described in the inline comment is now actually reachable.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
