### PR TITLE
feat: add consistency check for tabular

### DIFF
--- a/src/anemoi/datasets/create/tabular/creator.py
+++ b/src/anemoi/datasets/create/tabular/creator.py
@@ -94,6 +94,18 @@ class TabularCreator(Creator):
         """
         os.makedirs(self.work_dir, exist_ok=True)
 
+        # Guard against the pipeline producing columns that differ (in identity
+        # or order) from the schema recorded at initialisation. The fragments
+        # are saved as bare arrays, so this is the only place the column names
+        # still exist; checking here also catches a task running mismatched code.
+        expected = dataset.store.attrs["meta_variables"] + dataset.store.attrs["variables"]
+        actual = result.variables
+        assert actual == expected, (
+            f"Column schema mismatch for {result.start_range}..{result.end_range}:\n"
+            f"  pipeline produced: {actual}\n"
+            f"  metadata declares: {expected}"
+        )
+
         # Split large arrays into multiple files so that the finalisation step
         # does not need to load huge files into memory.
 

--- a/src/anemoi/datasets/create/tabular/finalise.py
+++ b/src/anemoi/datasets/create/tabular/finalise.py
@@ -698,6 +698,15 @@ def finalise_tabular_dataset(
     assert all(fragment.shape[1] == shape[1] for fragment in fragments), "Inconsistent number of columns in fragments"
     shape = (sum(fragment.shape[0] for fragment in fragments), fragments[0].shape[1])
 
+    # Backstop for the resume path: fragments reused from already-done groups
+    # are never revalidated against the metadata at load time, so confirm the
+    # on-disk width still matches the recorded schema before writing.
+    expected_cols = len(store.attrs["meta_variables"]) + len(variables_names)
+    assert shape[1] == expected_cols, (
+        f"Fragments have {shape[1]} columns but metadata declares {expected_cols} "
+        f"({len(store.attrs['meta_variables'])} meta + {len(variables_names)} variables)"
+    )
+
     LOG.info(f"First fragment: {fragments[0].first_date} to {fragments[0].last_date}")
     LOG.info(f"Last fragment : {fragments[-1].first_date} to {fragments[-1].last_date}")
 


### PR DESCRIPTION
These two safeguard should make dataset building crash when the tabular sources are giving inconsistent columns accross different groups.


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
