### PR TITLE
fix: pass options as kwarg in usage/_open

### DIFF
--- a/src/anemoi/datasets/usage/misc.py
+++ b/src/anemoi/datasets/usage/misc.py
@@ -361,10 +361,10 @@ def _open(a: str | PurePath | dict[str, Any] | list[Any] | tuple[Any, ...], opti
         return a.mutate()
 
     if isinstance(a, zarr.Group):
-        return ZarrStore.from_group(a, options).mutate()
+        return ZarrStore.from_group(a, options=options).mutate()
 
     if isinstance(a, str):
-        return ZarrStore.from_name_or_path(a, options).mutate()
+        return ZarrStore.from_name_or_path(a, options=options).mutate()
 
     if isinstance(a, PurePath):
         return _open(str(a), options).mutate()


### PR DESCRIPTION
## Description
Should fix an issue noticed when executing the `anemoi-datasets inspect` command – the _open function should pass options as a kwarg.

## What issue or task does this change relate to?
Should close #680 and #681

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
