### PR TITLE
feat: extend the xarray-kerchunk source

### DIFF
--- a/docs/building/sources/xarray-kerchunk.rst
+++ b/docs/building/sources/xarray-kerchunk.rst
@@ -2,10 +2,35 @@
  xarray-kerchunk
 #################
 
+This source is for building datasets from virtualised data in the form of
+`Kerchunk`_ references.
+
+Input references are supported as JSON strings, local and remote JSON file
+paths, and dictionaries.
+For remote file paths requiring configuration (e.g. authentication) to
+open, use the ``json_options`` field to pass relevant options to
+`fsspec.open`_.
+For loading remote data from references, use the ``storage_options`` field
+to pass relevant options to `xarray.open_dataset`_'s ``backend_kwargs``
+parameter.
+
+The below example recipe demonstrates building a dataset from a Kerchunk
+references JSON file stored in a private Azure Blob Storage container.
+Here, the JSON file and internally referenced data are stored in the same
+container requiring the same storage options.
+This recipe makes use of YAML anchors to avoid repetition of the same
+options in both fields.
+
 .. literalinclude:: yaml/xarray-kerchunk.yaml
    :language: yaml
 
-The code below is inspired by the `kerchunk tutorial`_, and makes use of
+.. warning::
+   Secrets included in the recipe are stored in plain text in the output
+   dataset's metadata (.zattrs file).
+   Prefer short-lived credentials (e.g. SAS tokens) and remove secrets
+   yourself where necessary.
+
+The code below is inspired by the `Kerchunk tutorial`_, and makes use of
 a subset of the `ERA5 dataset available on AWS`_. You may need to
 install the relevant packages before running the code below.
 
@@ -13,6 +38,12 @@ install the relevant packages before running the code below.
    :language: python
 
 See :ref:`create-cf-data` for more information.
+
+.. _kerchunk: https://fsspec.github.io/kerchunk/
+
+.. _fsspec.open: https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.open
+
+.. _xarray.open_dataset: https://docs.xarray.dev/en/stable/generated/xarray.open_dataset.html
 
 .. _era5 dataset available on aws: https://registry.opendata.aws/ecmwf-era5/
 

--- a/docs/building/sources/yaml/xarray-kerchunk.yaml
+++ b/docs/building/sources/yaml/xarray-kerchunk.yaml
@@ -5,6 +5,12 @@ dates:
 
 input:
   xarray-kerchunk:
-    json: combined.json
+    json: abfs://<container>/<path>/references.json
+    storage_options:
+      remote_protocol: abfs
+      remote_options: &options
+        account_name: <account>
+        sas_token: <token>
+    json_options: *options
     param: T
     level: [ 1000, 50 ]

--- a/src/anemoi/datasets/create/sources/xarray_kerchunk.py
+++ b/src/anemoi/datasets/create/sources/xarray_kerchunk.py
@@ -7,9 +7,17 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import json as json_mod
+import logging
+from pathlib import Path
+from typing import IO
+from typing import Any
+from typing import cast
 
 from . import source_registry
 from .xarray import XarraySourceBase
+
+LOG = logging.getLogger(__name__)
 
 
 @source_registry.register("xarray_kerchunk")
@@ -18,19 +26,71 @@ class XarrayKerchunkSource(XarraySourceBase):
 
     emoji = "🧱"
 
-    def __init__(self, context, json, *args, **kwargs: dict):
+    def __init__(
+        self,
+        context: Any,
+        json: str | dict,
+        *args: str,
+        json_options: dict[str, Any] | None = None,
+        storage_options: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialise the XarrayKerchunkSource.
+
+        Parameters
+        ----------
+        context : Any
+            Context for the data source.
+        json : str | dict
+            Kerchunk references as one of: a JSON string, a local JSON file path, a remote JSON file path, or a
+            dictionary of Kerchunk references.
+        *args
+            Additional positional arguments.
+        json_options : dict[str, Any] | None, default = None
+            Storage options passed to `fsspec.open` for opening a remote references JSON file.
+        storage_options : dict[str, Any] | None, default = None
+            Storage options passed to `xarray.open_zarr` for loading remote data from references.
+        **kwargs
+            Additional keyword arguments.
+
+        """
         super().__init__(context, *args, **kwargs)
 
         self.path_or_url = "reference://"
+
+        if isinstance(json, str):
+            if json.lstrip().startswith("{"):  # "looks like" JSON-formatted string of references
+                LOG.info("Using references JSON string.")
+                json = json_mod.loads(json)
+
+            elif (local_json := Path(json).resolve()).exists():
+                LOG.info("Using local references JSON file: %s", local_json)
+                with local_json.open() as f:
+                    json = json_mod.load(f)
+
+            else:
+                import fsspec  # type: ignore[import-untyped]
+
+                LOG.info("Using remote references JSON file: %s", json)
+                options = dict(json_options or {})
+                options["urlpath"] = json  # ensure urlpath arg not pre-set in json_options
+                with fsspec.open(**options) as f:
+                    json = json_mod.load(cast("IO[bytes]", f))
+
+        elif isinstance(json, dict):
+            LOG.info("Using references JSON dictionary.")
+
+        else:
+            msg = f"'json' must be a JSON string, file path, or dictionary, got {type(json)}."
+            raise TypeError(msg)
 
         self.options = {
             "engine": "zarr",
             "backend_kwargs": {
                 "consolidated": False,
                 "storage_options": {
-                    "fo": json,
-                    "remote_protocol": "s3",
-                    "remote_options": {"anon": True},
+                    **(storage_options or {}),
+                    "fo": json,  # last to override any setting in storage_options
                 },
             },
         }

--- a/tests/create/test_sources.py
+++ b/tests/create/test_sources.py
@@ -7,8 +7,11 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import json
 import os
 import shutil
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -423,33 +426,40 @@ def test_eccs_fstd(get_test_data: callable) -> None:
 @pytest.mark.slow
 @skip_if_offline
 @skip_missing_packages("kerchunk", "s3fs")
-def test_kerchunk(get_test_data: callable) -> None:
-    """Test for Kerchunk JSON files.
+@pytest.mark.parametrize("input_kind", ["path", "string", "dict", "url"])
+def test_kerchunk(get_test_data: Callable[[str, bool], str], input_kind: str) -> None:
+    """Test for Kerchunk JSON files with different input kinds."""
+    storage_opts = {"remote_protocol": "s3", "remote_options": {"anon": True}}
+    if input_kind == "url":
+        from anemoi.utils.testing import url_for_test_data
 
-    This function tests the creation of a dataset from a Kerchunk JSON file.
+        data_path = url_for_test_data("anemoi-datasets/create/kerchunck.json.gz")
+        json_opts = {"compression": "gzip"}
+    else:
+        data_path = get_test_data("anemoi-datasets/create/kerchunck.json", gzipped=True)
+        json_opts = {}
 
-    """
-    # Note: last version of kerchunk compatible with zarr 2 is 0.2.7
-
-    data = get_test_data("anemoi-datasets/create/kerchunck.json", gzipped=True)
+    if input_kind in ["path", "url"]:
+        json_arg = data_path
+    elif input_kind == "string":
+        json_arg = Path(data_path).read_text()
+    else:
+        with Path(data_path).open() as f:
+            json_arg = json.load(f)
 
     recipe = {
-        "dates": {
-            "start": "2024-03-01T00:00:00",
-            "end": "2024-03-01T18:00:00",
-            "frequency": "6h",
-        },
+        "dates": {"start": "2024-03-01T00:00:00", "end": "2024-03-01T18:00:00", "frequency": "6h"},
         "input": {
             "xarray-kerchunk": {
-                "json": data,
+                "json": json_arg,
+                "json_options": json_opts,
+                "storage_options": storage_opts,
                 "param": ["T"],
                 "level": [1000],
             },
         },
     }
-
-    created = create_dataset(recipe=recipe, output=None)
-    ds = open_dataset(created)
+    ds = open_dataset(create_dataset(recipe=recipe, output=None))
     assert ds.shape == (4, 1, 1, 1038240)
 
 


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

Extends the existing `XarrayKerchunkSource` to accept a wider range of inputs and to load data from more storage backends.

Input, previously inline dict only, now also accepts JSON string and local and remote JSON file paths.

Referenced data was previously anonymous S3 only. Source now supports any Fsspec-compatible backend, public and private.

Fsspec storage options for remote JSON files and remote referenced data are separately configurable to allow for different locations / auth.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

Expands the sources that virtualised data can be loaded from in creating datasets. No breaking changes to existing recipes.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

Closes #692 

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

One caveat is that [`anemoi.utils.sanitise.sanitise`](https://github.com/ecmwf/anemoi-utils/blob/98d2b119f18a19703342563f844c2c5f3153be3b/src/anemoi/utils/sanitise.py#L26) is not currently able to remove plain-text secrets from the recipe YAML prior to including them in output metadata (.zattrs). A warning of this has been added to the documentation.

Further, secrets, where necessary, must be included in the recipe YAML to begin with. A mechanism to dynamically insert or override recipe values on the command line could be useful. For example, `anemoi-datasets create recipe.yaml output.zarr --set inputs.xarray-kerchunk.storage_options.remote_options.sas_token="$SAS_TOKEN"`. Alternatively, env var interpolation within the YAML itself.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--699.org.readthedocs.build/en/699/

<!-- readthedocs-preview anemoi-datasets end -->