### PR TITLE
feat: accumulate variables to new temporal frequency 

### DIFF
--- a/src/anemoi/datasets/usage/dataset.py
+++ b/src/anemoi/datasets/usage/dataset.py
@@ -185,6 +185,20 @@ class Dataset(ABC, Sized):
                 Subset(self, self._dates_to_indices(start, end), dict(start=start, end=end))._subset(**kwargs).mutate()
             )
 
+        if "reaccumulate" in kwargs:
+            Reaccumulate = self.usage_factory_load("Reaccumulate")
+
+            if "interpolate_frequency" in kwargs:
+                raise ValueError("Cannot use both `reaccumulate` and `interpolate_frequency`")
+            if "frequency" not in kwargs:
+                raise ValueError("`reaccumulate` requires `frequency` to also be specified")
+
+            variables = kwargs.pop("reaccumulate")
+            frequency = kwargs.pop("frequency")
+            step = self._frequency_to_step(frequency)
+
+            return Reaccumulate(self, step, variables)._subset(**kwargs).mutate()
+
         if "frequency" in kwargs:
             Subset = self.usage_factory_load("Subset")
 
@@ -372,6 +386,30 @@ class Dataset(ABC, Sized):
 
         raise NotImplementedError("Unsupported arguments: " + ", ".join(kwargs))
 
+    def _frequency_to_step(self, frequency: str) -> int:
+        """Convert a frequency string to a step, i.e. the number of dataset
+        timesteps per requested timestep.
+
+        Parameters
+        ----------
+        frequency : str
+            The frequency string.
+
+        Returns
+        -------
+        int
+            The step.
+        """
+        requested_frequency = frequency_to_seconds(frequency)
+        dataset_frequency = frequency_to_seconds(self.frequency)
+
+        if requested_frequency % dataset_frequency != 0:
+            raise ValueError(
+                f"Requested frequency {frequency} is not a multiple of the dataset frequency {self.frequency}. Did you mean to use `interpolate_frequency`?"
+            )
+
+        return requested_frequency // dataset_frequency
+
     def _frequency_to_indices(self, frequency: str) -> list[int]:
         """Convert a frequency string to a list of indices.
 
@@ -385,16 +423,8 @@ class Dataset(ABC, Sized):
         list of int
             The list of indices.
         """
-        requested_frequency = frequency_to_seconds(frequency)
-        dataset_frequency = frequency_to_seconds(self.frequency)
-
-        if requested_frequency % dataset_frequency != 0:
-            raise ValueError(
-                f"Requested frequency {frequency} is not a multiple of the dataset frequency {self.frequency}. Did you mean to use `interpolate_frequency`?"
-            )
-
         # Question: where do we start? first date, or first date that is a multiple of the frequency?
-        step = requested_frequency // dataset_frequency
+        step = self._frequency_to_step(frequency)
 
         return range(0, len(self), step)
 

--- a/src/anemoi/datasets/usage/dataset.py
+++ b/src/anemoi/datasets/usage/dataset.py
@@ -197,7 +197,18 @@ class Dataset(ABC, Sized):
             frequency = kwargs.pop("frequency")
             step = self._frequency_to_step(frequency)
 
-            return Reaccumulate(self, step, variables)._subset(**kwargs).mutate()
+            return Reaccumulate.from_step(self, step, variables)._subset(**kwargs).mutate()
+
+        if "rolling_accumulate" in kwargs:
+            Reaccumulate = self.usage_factory_load("Reaccumulate")
+
+            if "window" not in kwargs:
+                raise ValueError("`rolling_accumulate` requires `window` to also be specified")
+
+            variables = kwargs.pop("rolling_accumulate")
+            window = kwargs.pop("window")
+
+            return Reaccumulate.from_window(self, window, variables)._subset(**kwargs).mutate()
 
         if "frequency" in kwargs:
             Subset = self.usage_factory_load("Subset")

--- a/src/anemoi/datasets/usage/gridded/reaccumulate.py
+++ b/src/anemoi/datasets/usage/gridded/reaccumulate.py
@@ -16,6 +16,8 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
+from anemoi.datasets import MissingDateError
+
 from ..dataset import Dataset
 from ..dataset import FullIndex
 from ..debug import Node
@@ -26,21 +28,89 @@ LOG = logging.getLogger(__name__)
 
 
 class Reaccumulate(Forwards):
-    """Resample a dataset to a coarser, but still exact, multiple of its
-    native frequency, re-accumulating selected variables instead of just
-    picking a single raw timestep.
+    """Resample selected variables to a windowed accumulation.
 
-    The dataset is split into non-overlapping blocks of ``step`` raw
-    timesteps. For each block, variables listed in ``variables`` (e.g.
-    ``tp``) are summed over the block, giving the accumulation over
-    the coarser period. All other variables are taken from the last raw
-    timestep of the block. Output dates are therefore the *end* of each
-    block, matching the usual convention that an accumulated field is
-    labelled with the end of its accumulation period.
+    Each output row ``n`` is anchored at raw index ``m = n * stride``. The
+    row's window spans the ``window_length`` raw timesteps ``[m, m +
+    window_length)``, and its own labelled date/raw-timestep sits at offset
+    ``-window[0]`` into that window. Variables listed in
+    ``variables`` are *summed* over the window; every other variable is taken
+    unchanged from the row's own labelled raw timestep.
+
+    ``stride`` controls whether this collapses the time axis or preserves it:
+
+    - ``stride == window_length`` -- windows are non-overlapping blocks, one
+      per output row, and the time axis collapses to a coarser frequency
+      (``stride * native frequency``). Use :meth:`from_step` for this shape,
+      e.g. re-accumulating hourly ``tp`` into a 6-hourly total.
+    - ``stride == 1`` -- windows slide by one raw timestep between rows, and
+      every native timestep is kept in the output. Use :meth:`from_window`
+      for this shape, e.g. a sliding 6-hourly accumulation of ``tp``
+      evaluated at every 3-hourly step for an input/target training scheme.
+
+    Other strides are accepted but not exercised by either convenience
+    constructor above.
     """
 
-    def __init__(self, dataset: Dataset, step: int, variables: list[str]) -> None:
+    def __init__(self, dataset: Dataset, window: tuple[int, int, str], stride: int, variables: list[str]) -> None:
         """Initialize the Reaccumulate class.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            The dataset to resample.
+        window : (int, int, str)
+            The accumulation window (start, end, 'freq'): both bounds
+            inclusive, in raw timesteps, relative to each row's own labelled
+            date, and 'freq' is currently the only supported unit.
+        stride : int
+            Number of raw timesteps between the anchors of consecutive
+            output rows. ``stride == window_length`` gives non-overlapping
+            blocks (frequency-collapsing); ``stride == 1`` gives a sliding
+            window (frequency-preserving).
+        variables : list of str
+            Names of the variables to sum over each window. Any other
+            variable is taken from its own raw timestep, unchanged.
+        """
+        super().__init__(dataset)
+
+        if not (isinstance(window, (list, tuple)) and len(window) == 3):
+            raise ValueError(f"Window must be (int, int, str), got {window}")
+        if not isinstance(window[0], int) or not isinstance(window[1], int) or not isinstance(window[2], str):
+            raise ValueError(f"Window must be (int, int, str), got {window}")
+        if window[2] not in ["freq", "frequency"]:
+            raise NotImplementedError(f"Window must be (int, int, 'freq'), got {window}")
+
+        # window = (0, 0, 'freq') means no change
+        self.i_start = -window[0]
+        self.i_end = window[1] + 1
+        if self.i_start < 0:
+            raise ValueError(f"Window start must be negative, got {window}")
+        if self.i_end <= 0:
+            raise ValueError(f"Window end must be positive, got {window}")
+
+        self.window_str = f"-{self.i_start}-to-{self.i_end}"
+        self.window_length = self.i_start + self.i_end
+
+        if not isinstance(stride, int) or stride < 1:
+            raise ValueError(f"stride must be a positive integer, got {stride}")
+        self.stride = stride
+
+        name_to_index = dataset.name_to_index
+        unknown = [v for v in variables if v not in name_to_index]
+        if unknown:
+            raise ValueError(f"reaccumulate: unknown variable(s) {unknown}, available: {list(name_to_index)}")
+
+        self._check_accumulation_periods(dataset, variables, self.window_length * dataset.frequency)
+
+        self.accumulated_variables: list[str] = list(variables)
+        self.accumulated_indices: list[int] = [name_to_index[v] for v in variables]
+
+    @classmethod
+    def from_step(cls, dataset: Dataset, step: int, variables: list[str]) -> "Reaccumulate":
+        """Non-overlapping block accumulation: collapse the time axis to a
+        coarser frequency (``step`` raw timesteps per output row), summing
+        ``variables`` over each block.
 
         Parameters
         ----------
@@ -51,33 +121,39 @@ class Reaccumulate(Forwards):
             between the requested frequency and the dataset's native
             frequency).
         variables : list of str
-            Names of the variables to sum over each block. Any other
-            variable is taken from the last raw timestep of the block.
+            Names of the variables to sum over each block.
         """
-        super().__init__(dataset)
-
         if not isinstance(step, int) or step < 1:
             raise ValueError(f"step must be a positive integer, got {step}")
-        self.step = step
+        return cls(dataset, (-(step - 1), 0, "freq"), step, variables)
 
-        name_to_index = dataset.name_to_index
-        unknown = [v for v in variables if v not in name_to_index]
-        if unknown:
-            raise ValueError(f"reaccumulate: unknown variable(s) {unknown}, available: {list(name_to_index)}")
+    @classmethod
+    def from_window(cls, dataset: Dataset, window: tuple[int, int, str], variables: list[str]) -> "Reaccumulate":
+        """Sliding-window accumulation: keep the dataset at its native
+        frequency, summing ``variables`` over a window of raw timesteps
+        around every row.
 
-        self._check_accumulation_periods(dataset, variables, step * dataset.frequency)
-
-        self.accumulated_variables: list[str] = list(variables)
-        self.accumulated_indices: list[int] = [name_to_index[v] for v in variables]
+        Parameters
+        ----------
+        dataset : Dataset
+            The dataset to resample.
+        window : (int, int, str)
+            The rolling window (start, end, 'freq'), see the class
+            docstring. For a trailing accumulation ending at each output
+            row's own labelled date (e.g. combining two 3h increments into a
+            6h total), use ``(-1, 0, "freq")``.
+        variables : list of str
+            Names of the variables to sum over the window.
+        """
+        return cls(dataset, window, 1, variables)
 
     @staticmethod
-    def _check_accumulation_periods(
-        dataset: Dataset, variables: list[str], frequency: datetime.timedelta
-    ) -> None:
+    def _check_accumulation_periods(dataset: Dataset, variables: list[str], target_period: datetime.timedelta) -> None:
         """Fail if a variable's own accumulation period (from the dataset's
-        metadata) is not a proper factor of the requested output frequency,
-        since summing raw timesteps whose accumulation window doesn't evenly
-        tile the requested period would silently produce an incorrect total.
+        metadata) is not a proper factor of ``target_period`` (the period
+        being summed over, i.e. ``window_length * native frequency``), since
+        summing raw timesteps whose accumulation window doesn't evenly tile
+        that period would silently produce an incorrect total.
 
         Variables with no recorded accumulation period (missing/empty
         metadata) are skipped.
@@ -94,14 +170,14 @@ class Reaccumulate(Forwards):
             if not period:
                 continue
 
-            if frequency % period != datetime.timedelta(0):
+            if target_period % period != datetime.timedelta(0):
                 raise ValueError(
-                    f"reaccumulate: variable {var!r} has an accumulation period of {period}, which is not "
-                    f"a proper factor of the requested frequency {frequency}."
+                    f"variable {var!r} has an accumulation period of {period}, which is not a proper "
+                    f"factor of the period being summed over ({target_period})."
                 )
 
     def __len__(self) -> int:
-        return len(self.forward) // self.step
+        return (len(self.forward) - self.window_length) // self.stride + 1
 
     @property
     def shape(self):
@@ -111,14 +187,26 @@ class Reaccumulate(Forwards):
 
     @cached_property
     def dates(self) -> NDArray[np.datetime64]:
-        """Dates of each block, taken as the last raw date in the block."""
-        dates = self.forward.dates
-        return dates[self.step - 1 :: self.step][: len(self)]
+        """Dates of each row, taken as the labelled raw date within its window."""
+        indices = self.i_start + self.stride * np.arange(len(self))
+        return self.forward.dates[indices]
 
     @cached_property
     def frequency(self) -> datetime.timedelta:
-        """Effective frequency of the resampled dataset (step * native frequency)."""
-        return self.step * self.forward.frequency
+        """Effective frequency of the resampled dataset: the raw-timestep
+        spacing between consecutive output rows' labelled dates
+        (``stride * native frequency``, regardless of ``window_length``).
+        """
+        return self.stride * self.forward.frequency
+
+    def _raise_if_missing_in_window(self, n: int, forward_missing: set[int]) -> None:
+        m = n * self.stride
+        for j in range(m, m + self.window_length):
+            if j in forward_missing:
+                raise MissingDateError(
+                    f"Reaccumulate window for date {self.forward.dates[m + self.i_start]} "
+                    f"overlaps with missing forward index {j} (date {self.forward.dates[j]})"
+                )
 
     def _get_one(self, n: int, rest: tuple) -> NDArray[Any]:
         if n < 0:
@@ -126,14 +214,19 @@ class Reaccumulate(Forwards):
         if n < 0 or n >= len(self):
             raise IndexError(f"Index out of range: {n}")
 
-        start = n * self.step
+        forward_missing = self.forward.missing
+        if forward_missing:
+            self._raise_if_missing_in_window(n, forward_missing)
+
+        m = n * self.stride
+        label_index = m + self.i_start
         var_index = rest[0] if rest else slice(None)
         other_rest = rest[1:] if rest else ()
 
-        # Non-accumulated variables only need the last raw timestep of the
-        # block, and any variable/grid subsetting is pushed down into the
-        # forward fetch.
-        result = self.forward[(start + self.step - 1, var_index) + other_rest]
+        # Non-accumulated variables only need the raw timestep matching this
+        # row's labelled date, and any variable/grid subsetting is pushed
+        # down into the forward fetch. 
+        result = self.forward[(slice(label_index, label_index + 1), var_index) + other_rest][0]
 
         if not self.accumulated_indices:
             return result
@@ -145,8 +238,8 @@ class Reaccumulate(Forwards):
             var = var_index if var_index >= 0 else var_index + n_vars
             if var not in accumulated_set:
                 return result
-            block = self.forward[(slice(start, start + self.step), var) + other_rest]
-            return np.sum(block, axis=0)
+            window = self.forward[(slice(m, m + self.window_length), var) + other_rest]
+            return np.sum(window, axis=0)
 
         if isinstance(var_index, slice):
             requested = list(range(*var_index.indices(n_vars)))
@@ -159,9 +252,9 @@ class Reaccumulate(Forwards):
             return result
 
         acc_vars = [requested[p] for p in acc_positions]
-        block = self.forward[(slice(start, start + self.step), acc_vars) + other_rest]
+        window = self.forward[(slice(m, m + self.window_length), acc_vars) + other_rest]
         result = np.array(result, copy=True)
-        result[acc_positions] = np.sum(block, axis=0)
+        result[acc_positions] = np.sum(window, axis=0)
         return result
 
     @debug_indexing
@@ -181,20 +274,26 @@ class Reaccumulate(Forwards):
 
     @cached_property
     def missing(self) -> set[int]:
-        """A block is missing if any raw timestep it is built from is missing."""
+        """A row is missing if any raw timestep its window depends on is missing."""
         forward_missing = self.forward.missing
         if not forward_missing:
             return set()
 
         result = set()
         for n in range(len(self)):
-            start = n * self.step
-            if any(i in forward_missing for i in range(start, start + self.step)):
+            m = n * self.stride
+            if any(i in forward_missing for i in range(m, m + self.window_length)):
                 result.add(n)
         return result
 
     def tree(self) -> Node:
-        return Node(self, [self.forward.tree()], step=self.step, reaccumulate=self.accumulated_variables)
+        return Node(
+            self,
+            [self.forward.tree()],
+            window=self.window_str,
+            stride=self.stride,
+            reaccumulate=self.accumulated_variables,
+        )
 
     def forwards_subclass_metadata_specific(self) -> dict[str, Any]:
-        return dict(step=self.step, reaccumulate=self.accumulated_variables)
+        return dict(window=self.window_str, stride=self.stride, reaccumulate=self.accumulated_variables)

--- a/src/anemoi/datasets/usage/gridded/reaccumulate.py
+++ b/src/anemoi/datasets/usage/gridded/reaccumulate.py
@@ -225,7 +225,7 @@ class Reaccumulate(Forwards):
 
         # Non-accumulated variables only need the raw timestep matching this
         # row's labelled date, and any variable/grid subsetting is pushed
-        # down into the forward fetch. 
+        # down into the forward fetch.
         result = self.forward[(slice(label_index, label_index + 1), var_index) + other_rest][0]
 
         if not self.accumulated_indices:

--- a/src/anemoi/datasets/usage/gridded/reaccumulate.py
+++ b/src/anemoi/datasets/usage/gridded/reaccumulate.py
@@ -1,0 +1,168 @@
+# (C) Copyright 2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+import datetime
+import logging
+from functools import cached_property
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..dataset import Dataset
+from ..dataset import FullIndex
+from ..debug import Node
+from ..debug import debug_indexing
+from ..forwards import Forwards
+
+LOG = logging.getLogger(__name__)
+
+
+class Reaccumulate(Forwards):
+    """Resample a dataset to a coarser, but still exact, multiple of its
+    native frequency, re-accumulating selected variables instead of just
+    picking a single raw timestep.
+
+    The dataset is split into non-overlapping blocks of ``step`` raw
+    timesteps. For each block, variables listed in ``variables`` (e.g.
+    ``tp``) are summed over the block, giving the accumulation over
+    the coarser period. All other variables are taken from the last raw
+    timestep of the block. Output dates are therefore the *end* of each
+    block, matching the usual convention that an accumulated field is
+    labelled with the end of its accumulation period.
+    """
+
+    def __init__(self, dataset: Dataset, step: int, variables: list[str]) -> None:
+        """Initialize the Reaccumulate class.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            The dataset to resample.
+        step : int
+            Number of raw timesteps per output timestep (i.e. the ratio
+            between the requested frequency and the dataset's native
+            frequency).
+        variables : list of str
+            Names of the variables to sum over each block. Any other
+            variable is taken from the last raw timestep of the block.
+        """
+        super().__init__(dataset)
+
+        if not isinstance(step, int) or step < 1:
+            raise ValueError(f"step must be a positive integer, got {step}")
+        self.step = step
+
+        name_to_index = dataset.name_to_index
+        unknown = [v for v in variables if v not in name_to_index]
+        if unknown:
+            raise ValueError(f"reaccumulate: unknown variable(s) {unknown}, available: {list(name_to_index)}")
+
+        self.accumulated_variables: list[str] = list(variables)
+        self.accumulated_indices: list[int] = [name_to_index[v] for v in variables]
+
+    def __len__(self) -> int:
+        return len(self.forward) // self.step
+
+    @property
+    def shape(self):
+        shape = list(self.forward.shape)
+        shape[0] = len(self)
+        return tuple(shape)
+
+    @cached_property
+    def dates(self) -> NDArray[np.datetime64]:
+        """Dates of each block, taken as the last raw date in the block."""
+        dates = self.forward.dates
+        return dates[self.step - 1 :: self.step][: len(self)]
+
+    @cached_property
+    def frequency(self) -> datetime.timedelta:
+        """Effective frequency of the resampled dataset (step * native frequency)."""
+        return self.step * self.forward.frequency
+
+    def _get_one(self, n: int, rest: tuple) -> NDArray[Any]:
+        if n < 0:
+            n = len(self) + n
+        if n < 0 or n >= len(self):
+            raise IndexError(f"Index out of range: {n}")
+
+        start = n * self.step
+        var_index = rest[0] if rest else slice(None)
+        other_rest = rest[1:] if rest else ()
+
+        # Non-accumulated variables only need the last raw timestep of the
+        # block, and any variable/grid subsetting is pushed down into the
+        # forward fetch.
+        result = self.forward[(start + self.step - 1, var_index) + other_rest]
+
+        if not self.accumulated_indices:
+            return result
+
+        n_vars = self.forward.shape[1]
+        accumulated_set = set(self.accumulated_indices)
+
+        if isinstance(var_index, int):
+            var = var_index if var_index >= 0 else var_index + n_vars
+            if var not in accumulated_set:
+                return result
+            block = self.forward[(slice(start, start + self.step), var) + other_rest]
+            return np.sum(block, axis=0)
+
+        if isinstance(var_index, slice):
+            requested = list(range(*var_index.indices(n_vars)))
+        else:
+            values = var_index.tolist() if hasattr(var_index, "tolist") else var_index
+            requested = [v if v >= 0 else v + n_vars for v in values]
+
+        acc_positions = [p for p, v in enumerate(requested) if v in accumulated_set]
+        if not acc_positions:
+            return result
+
+        acc_vars = [requested[p] for p in acc_positions]
+        block = self.forward[(slice(start, start + self.step), acc_vars) + other_rest]
+        result = np.array(result, copy=True)
+        result[acc_positions] = np.sum(block, axis=0)
+        return result
+
+    @debug_indexing
+    def __getitem__(self, n: FullIndex) -> NDArray[Any]:
+        if isinstance(n, tuple):
+            first, rest = n[0], n[1:]
+        else:
+            first, rest = n, ()
+
+        if isinstance(first, slice):
+            first = list(range(*first.indices(len(self))))
+
+        if isinstance(first, (list, tuple)):
+            return np.stack([self._get_one(i, rest) for i in first])
+
+        return self._get_one(first, rest)
+
+    @cached_property
+    def missing(self) -> set[int]:
+        """A block is missing if any raw timestep it is built from is missing."""
+        forward_missing = self.forward.missing
+        if not forward_missing:
+            return set()
+
+        result = set()
+        for n in range(len(self)):
+            start = n * self.step
+            if any(i in forward_missing for i in range(start, start + self.step)):
+                result.add(n)
+        return result
+
+    def tree(self) -> Node:
+        return Node(self, [self.forward.tree()], step=self.step, reaccumulate=self.accumulated_variables)
+
+    def forwards_subclass_metadata_specific(self) -> dict[str, Any]:
+        return dict(step=self.step, reaccumulate=self.accumulated_variables)

--- a/src/anemoi/datasets/usage/gridded/reaccumulate.py
+++ b/src/anemoi/datasets/usage/gridded/reaccumulate.py
@@ -65,8 +65,40 @@ class Reaccumulate(Forwards):
         if unknown:
             raise ValueError(f"reaccumulate: unknown variable(s) {unknown}, available: {list(name_to_index)}")
 
+        self._check_accumulation_periods(dataset, variables, step * dataset.frequency)
+
         self.accumulated_variables: list[str] = list(variables)
         self.accumulated_indices: list[int] = [name_to_index[v] for v in variables]
+
+    @staticmethod
+    def _check_accumulation_periods(
+        dataset: Dataset, variables: list[str], frequency: datetime.timedelta
+    ) -> None:
+        """Fail if a variable's own accumulation period (from the dataset's
+        metadata) is not a proper factor of the requested output frequency,
+        since summing raw timesteps whose accumulation window doesn't evenly
+        tile the requested period would silently produce an incorrect total.
+
+        Variables with no recorded accumulation period (missing/empty
+        metadata) are skipped.
+        """
+        from anemoi.transform.variables import Variable
+
+        metadata = dataset.variables_metadata
+        for var in variables:
+            meta = metadata.get(var)
+            if not meta:
+                continue
+
+            period = Variable.from_dict(var, meta).period
+            if not period:
+                continue
+
+            if frequency % period != datetime.timedelta(0):
+                raise ValueError(
+                    f"reaccumulate: variable {var!r} has an accumulation period of {period}, which is not "
+                    f"a proper factor of the requested frequency {frequency}."
+                )
 
     def __len__(self) -> int:
         return len(self.forward) // self.step

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -32,7 +32,6 @@ from anemoi.datasets.usage.gridded.ensemble import Ensemble
 from anemoi.datasets.usage.gridded.grids import GridsBase
 from anemoi.datasets.usage.gridded.join import Join
 from anemoi.datasets.usage.gridded.masked import Masking
-from anemoi.datasets.usage.gridded.reaccumulate import Reaccumulate
 from anemoi.datasets.usage.gridded.select import Select
 from anemoi.datasets.usage.gridded.statistics import Statistics
 from anemoi.datasets.usage.gridded.store import GriddedZarr

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -32,6 +32,7 @@ from anemoi.datasets.usage.gridded.ensemble import Ensemble
 from anemoi.datasets.usage.gridded.grids import GridsBase
 from anemoi.datasets.usage.gridded.join import Join
 from anemoi.datasets.usage.gridded.masked import Masking
+from anemoi.datasets.usage.gridded.reaccumulate import Reaccumulate
 from anemoi.datasets.usage.gridded.select import Select
 from anemoi.datasets.usage.gridded.statistics import Statistics
 from anemoi.datasets.usage.gridded.store import GriddedZarr
@@ -1526,6 +1527,93 @@ def test_rolling_average() -> None:
 
     diff = test.ds[0] - (initial.ds[0:5].sum(axis=0) / 5)
     assert np.abs(diff).max() < 1e-5
+
+
+# `default_test_indexing` hard-codes a mixed variable-list index `(1, 2)` (i.e. "b",
+# "c" for the "abcd" fixture). Accumulating "b" means that list always mixes an
+# accumulated and a non-accumulated variable, exercising the acc_positions branch of
+# `_get_one` -- the exact shape that triggered the bare-int-plus-list-index axis-order
+# bug found during manual verification.
+
+
+@mockup_open_zarr
+def test_reaccumulate_block() -> None:
+    """reaccumulate= + frequency=: non-overlapping blocks, time axis collapses."""
+    initial = DatasetTester("test-2021-2021-6h-o96-abcd")
+    test = DatasetTester(
+        "test-2021-2021-6h-o96-abcd",
+        reaccumulate=["b"],
+        frequency="12h",
+    )
+
+    n = len(initial.ds) // 2
+    assert test.ds.shape == (n, 4, 1, 10)
+    assert test.ds.frequency == datetime.timedelta(hours=12)
+
+    a_index = initial.ds.name_to_index["a"]
+    b_index = initial.ds.name_to_index["b"]
+
+    raw_b = initial.ds[: n * 2, b_index]
+    expected_b = raw_b.reshape(n, 2, *raw_b.shape[1:]).sum(axis=1)
+    assert np.allclose(test.ds[:, b_index], expected_b)
+
+    # non-accumulated variable is taken from the last raw timestep of each block
+    raw_a = initial.ds[1 : n * 2 : 2, a_index]
+    assert np.allclose(test.ds[:, a_index], raw_a)
+
+    assert (test.ds.dates == initial.ds.dates[1 : n * 2 : 2]).all()
+
+    default_test_indexing(test.ds)
+
+
+@mockup_open_zarr
+def test_reaccumulate_rolling() -> None:
+    """rolling_accumulate= + window=: sliding window, native frequency kept."""
+    initial = DatasetTester("test-2021-2021-6h-o96-abcd")
+    test = DatasetTester(
+        "test-2021-2021-6h-o96-abcd",
+        rolling_accumulate=["b"],
+        window=(-1, 0, "freq"),
+    )
+
+    n = len(initial.ds) - 1
+    assert test.ds.shape == (n, 4, 1, 10)
+    assert test.ds.frequency == datetime.timedelta(hours=6)
+
+    a_index = initial.ds.name_to_index["a"]
+    b_index = initial.ds.name_to_index["b"]
+
+    raw_b = initial.ds[:, b_index]
+    expected_b = raw_b[:n] + raw_b[1 : n + 1]
+    assert np.allclose(test.ds[:, b_index], expected_b)
+
+    # non-accumulated variable is taken from each row's own labelled timestep
+    assert np.allclose(test.ds[:, a_index], initial.ds[1 : n + 1, a_index])
+
+    assert (test.ds.dates == initial.ds.dates[1 : n + 1]).all()
+
+    default_test_indexing(test.ds)
+
+
+@mockup_open_zarr
+def test_reaccumulate_unknown_variable() -> None:
+    with pytest.raises(ValueError):
+        DatasetTester("test-2021-2021-6h-o96-abcd", reaccumulate=["zz"], frequency="12h")
+
+    with pytest.raises(ValueError):
+        DatasetTester("test-2021-2021-6h-o96-abcd", rolling_accumulate=["zz"], window=(-1, 0, "freq"))
+
+
+@mockup_open_zarr
+def test_reaccumulate_requires_frequency() -> None:
+    with pytest.raises(ValueError):
+        DatasetTester("test-2021-2021-6h-o96-abcd", reaccumulate=["a"])
+
+
+@mockup_open_zarr
+def test_reaccumulate_rolling_requires_window() -> None:
+    with pytest.raises(ValueError):
+        DatasetTester("test-2021-2021-6h-o96-abcd", rolling_accumulate=["a"])
 
 
 @mockup_open_zarr


### PR DESCRIPTION
## Description 

When combining datasets with different temporal frequencies, variables such as tp, ssrd and strd are incompatible due to a different accumulation period. The best solution is to regenerate the dataset with the correct accumulation period, but this can be time-consuming. Here, we provide an alternative option to reaccumulate variables (e.g., 3h to 6h, or 1h to 6h) without recreating the dataset. This is implemented using a new class inspired by the existing RollingAverage functionality. 

Usage 

```
ds = open_dataset( 
   "dataset", 
   frequency="6h", 
   reaccumulate=["tp"],   # any other accumulated variables can be listed too 
) 
```

### Validation 

Figures below show the results of reaccumulating tp from 3h to 6h for the CERRA (Figs. 1–2) and UWC-West (Figs. 3–4) datasets. The distributions of tp_6h and its reaccumulated version match well (Figs 1,3), with differences mainly visibile for very small precipitation amounts (<0.01 mm). Absolute differences between tp_6h and its reaccumulated version are also small, typically between -0.05 to 0.05 mm (CERRA) or -0.1 to 0.1mm (UWC-West). 

<figure>
    <img width="1900" height="1100" alt="cerra_histograms_3way" src="https://github.com/user-attachments/assets/a518c9e8-168b-4158-8f41-6c57315f1863" />
    <figcaption>Figure 1. Distribution of tp for 3h (blue), 6h (red) and reaccumulated 6h (green) for the CERRA dataset.</figcaption>
</figure>

<figure>
  <img width="1795" height="713" alt="cerra_histogram" src="https://github.com/user-attachments/assets/90bc0019-377f-4b63-bd7d-b38cbc53808a" />
    <figcaption>Figure 2. Histogram of differences between tp_6h and its reaccumulated version for the CERRA dataset. </figcaption>
</figure>

<figure>
  <img width="1900" height="1100" alt="uwcwest_histograms_3way" src="https://github.com/user-attachments/assets/7ea64b6f-bf29-4b49-be14-d8bb1710c1f0" />
    <figcaption>Figure 3. Distribution of tp for 3h (blue), 6h (red) and reaccumulated 6h (green) for the UWC-West dataset.  </figcaption>
</figure>

<figure>
  <img width="1797" height="707" alt="histogram" src="https://github.com/user-attachments/assets/bb02975c-6d60-4747-9fd8-5c00b093bcfc" />
    <figcaption>Figure 4. Histogram of differences between tp_6h and its reaccumulated version for the UWC-West dataset. </figcaption>
</figure>

## What problem does this change solve? 

This change solves problems related to variable compatibility, such as the one below: 

``` 

  File "/perm/nld4523/venv_jun2026_AG_CUDA13/lib/python3.12/site-packages/anemoi/datasets/usage/forwards.py", line 500, in check_variables_compatibility 

    Variable.check_compatibility( 

  File "/lus/h2resw01/hpcperm/nld4523/anemoi_jun2026/anemoi-transform/src/anemoi/transform/variables/__init__.py", line 367, in check_compatibility 

    raise ValueError(f"Variables are not compatible: {'; '.join(reasons)}") 

ValueError: Variables are not compatible: tp: Periods are not compatible: 6:00:00 vs 1:00:00; ssrd: Periods are not compatible: 6:00:00 vs 1:00:00; strd: Periods are not compatible: 6:00:00 vs 1:00:00 

``` 

## What issue or task does this change relate to? 

This PR is a follow-up of feature request #222 (https://github.com/ecmwf/anemoi-datasets/issues/222).  