### PR TITLE
fix(create): height coord standard name

### DIFF
--- a/src/anemoi/datasets/create/sources/xarray_support/flavour.py
+++ b/src/anemoi/datasets/create/sources/xarray_support/flavour.py
@@ -767,6 +767,9 @@ class DefaultCoordinateGuesser(CoordinateGuesser):
         if attributes.standard_name == "model_level_number":
             return LevelCoordinate(c, "ml")
 
+        if attributes.standard_name == "height" and attributes.units == "m":
+            return LevelCoordinate(c, "height")
+
         if attributes.long_name == "height" and attributes.units == "m":
             return LevelCoordinate(c, "height")
 

--- a/tests/xarray/test_flavour.py
+++ b/tests/xarray/test_flavour.py
@@ -76,6 +76,7 @@ def create_ds(var_name, standard_name, long_name, units, coord_length=5):
         # level
         ("lev", "atmosphere_hybrid_sigma_pressure_coordinate", None, None, LevelCoordinate),
         ("h", None, "height", "m", LevelCoordinate),
+        ("h", "height", None, "m", LevelCoordinate),
         ("level", "air_pressure", None, "hPa", LevelCoordinate),
         ("pressure_0", None, "pressure", "hPa", LevelCoordinate),
         ("pressure_0", None, "pressure", "Pa", LevelCoordinate),


### PR DESCRIPTION
## Description

Adds support for height coordinates with `height` as the `standard_name`

## What problem does this change solve?

Bugfix - height coordinates with `height` as `standard_name` are not currently supported and parameters are silently ignored.

## What issue or task does this change relate to?

Closes #706 

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
