### PR TITLE
feat: broadcast-to-trajectories-in-open-dataset

### DIFF
--- a/src/anemoi/datasets/usage/misc.py
+++ b/src/anemoi/datasets/usage/misc.py
@@ -589,6 +589,17 @@ def _open_dataset(*args: Any, options: Options = None, **kwargs: Any) -> "Datase
     assert len(sets) > 0, (args, kwargs)
 
     if len(sets) > 1:
+        from anemoi.datasets.usage.trajectories.join import is_trajectory
+
+        if any(is_trajectory(d) for d in sets):
+            # A mix containing at least one trajectories dataset is overlaid
+            # along the variable axis: gridded members are broadcast onto the
+            # trajectory layout by valid-time lookup. The result behaves like a
+            # trajectories dataset.
+            from anemoi.datasets.usage.trajectories.join import trajectory_join
+
+            return trajectory_join(sets, options)._subset(**kwargs)
+
         dataset, kwargs = _concat_or_join(sets, kwargs, options)
         return dataset._subset(**kwargs)
 

--- a/src/anemoi/datasets/usage/trajectories/broadcast.py
+++ b/src/anemoi/datasets/usage/trajectories/broadcast.py
@@ -1,0 +1,301 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Broadcast a gridded dataset onto a trajectories layout.
+
+A gridded dataset has the 4-D layout ``(dates, variables, ensembles, cells)``
+and no step axis.  :class:`GriddedAsTrajectory` presents it as a 5-D
+trajectories dataset ``(base_dates, variables, ensembles, steps, cells)`` by
+looking the gridded fields up on **valid time**: the value placed at trajectory
+position ``(base date b, step s)`` is the gridded field at valid time
+``b + s``.  The same gridded field is therefore duplicated wherever two
+``(base, step)`` pairs share a valid time, and every required valid time must be
+present in the gridded dataset (otherwise construction fails).
+
+This wrapper is an implementation detail of :func:`trajectory_join`; it is not
+meant to be opened directly.
+"""
+
+import datetime
+import logging
+from functools import cached_property
+from typing import Any
+
+import numpy as np
+from anemoi.utils.dates import frequency_to_timedelta
+from numpy.typing import NDArray
+
+from anemoi.datasets.usage.dataset import Dataset
+from anemoi.datasets.usage.dataset import FullIndex
+from anemoi.datasets.usage.dataset import Shape
+from anemoi.datasets.usage.debug import Node
+from anemoi.datasets.usage.forwards import Forwards
+from anemoi.datasets.usage.trajectories.metadata import trajectory_metadata
+
+LOG = logging.getLogger(__name__)
+
+
+class GriddedAsTrajectory(Forwards):
+    """View a gridded dataset as a trajectories dataset by valid-time lookup.
+
+    Parameters
+    ----------
+    dataset : Dataset
+        The underlying gridded dataset (4-D layout).
+    base_dates : NDArray[np.datetime64]
+        The target base dates, taken from the trajectory template.
+    steps : NDArray[np.timedelta64]
+        The target forecast steps, taken from the trajectory template.
+    """
+
+    def __init__(
+        self,
+        dataset: Dataset,
+        base_dates: NDArray[np.datetime64],
+        steps: NDArray[np.timedelta64],
+    ) -> None:
+        super().__init__(dataset)
+        self._base_dates = base_dates.astype("datetime64[s]")
+        self._steps = steps.astype("timedelta64[s]")
+        self._index_map = self._build_index_map()
+
+    def _build_index_map(self) -> NDArray[np.int64]:
+        """Map each ``(base date, step)`` pair to a row in the gridded dataset.
+
+        Returns
+        -------
+        NDArray[np.int64]
+            An ``(n_base_dates, n_steps)`` array of indices into the gridded
+            dataset's date axis.
+
+        Raises
+        ------
+        ValueError
+            If any required valid time is not present in the gridded dataset.
+        """
+        gridded_dates = self.forward.dates.astype("datetime64[s]")
+        lookup = {d: i for i, d in enumerate(gridded_dates.tolist())}
+
+        # valid[i, j] = base_dates[i] + steps[j]
+        valid = self._base_dates[:, None] + self._steps[None, :]
+
+        index_map = np.empty(valid.shape, dtype=np.int64)
+        missing: set[np.datetime64] = set()
+        for i in range(valid.shape[0]):
+            for j in range(valid.shape[1]):
+                t = valid[i, j].tolist()
+                k = lookup.get(t)
+                if k is None:
+                    missing.add(valid[i, j])
+                else:
+                    index_map[i, j] = k
+
+        if missing:
+            sample = sorted(str(np.datetime64(m, "s")) for m in missing)[:10]
+            raise ValueError(
+                f"{self.forward} does not cover {len(missing)} valid time(s) required to broadcast "
+                f"it onto the trajectory (base_date + step). First missing: {sample}"
+            )
+
+        return index_map
+
+    def mutate(self) -> Dataset:
+        return self
+
+    # ------------------------------------------------------------------
+    # Shape and indexing
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        """Return the number of base dates."""
+        return len(self._base_dates)
+
+    @cached_property
+    def shape(self) -> Shape:
+        """Return the 5-D shape ``(base_dates, variables, ensembles, steps, cells)``."""
+        variables, ensembles, cells = self.forward.shape[1], self.forward.shape[2], self.forward.shape[3]
+        return (len(self), variables, ensembles, len(self._steps), cells)
+
+    def _single(self, i: int) -> NDArray[Any]:
+        """Return the broadcast field for a single base date.
+
+        Parameters
+        ----------
+        i : int
+            Index along the base-date axis.
+
+        Returns
+        -------
+        NDArray[Any]
+            An array of shape ``(variables, ensembles, steps, cells)``.
+        """
+        # Look up the gridded field (variables, ensembles, cells) for the valid
+        # time of every step, and stack them along the step axis (position -2).
+        fields = [self.forward[int(k)] for k in self._index_map[i]]
+        return np.stack(fields, axis=-2)
+
+    def __getitem__(self, n: FullIndex) -> NDArray[Any]:
+        """Return data for the given base-date index.
+
+        Parameters
+        ----------
+        n : int, slice, list, tuple or ndarray
+            Index into the base-date axis (and, for tuples, the trailing axes).
+
+        Returns
+        -------
+        NDArray[Any]
+            The requested slice of the 5-D array.
+        """
+        if isinstance(n, tuple):
+            # Resolve the base-date axis first (which inserts the step axis),
+            # then apply the remaining indices with plain numpy semantics — the
+            # underlying gridded array is 4-D, so a tuple cannot be forwarded.
+            result = self[n[0]]
+            rest = n[1:]
+            if not rest:
+                return result
+            if isinstance(n[0], (int, np.integer)):
+                return result[rest]
+            return result[(slice(None),) + rest]
+
+        if isinstance(n, slice):
+            return np.stack([self._single(i) for i in range(*n.indices(len(self)))])
+
+        if isinstance(n, (list, np.ndarray)):
+            return np.stack([self._single(int(i)) for i in n])
+
+        return self._single(int(n))
+
+    # ------------------------------------------------------------------
+    # Base-date axis
+    # ------------------------------------------------------------------
+
+    @property
+    def base_dates(self) -> NDArray[np.datetime64]:
+        """Return the base dates."""
+        return self._base_dates
+
+    @property
+    def base_start_date(self) -> np.datetime64:
+        """Return the first base date."""
+        return self._base_dates[0]
+
+    @property
+    def base_end_date(self) -> np.datetime64:
+        """Return the last base date."""
+        return self._base_dates[-1]
+
+    @property
+    def base_frequency(self) -> datetime.timedelta:
+        """Return the interval between consecutive base dates."""
+        dates = self._base_dates
+        if len(dates) < 2:
+            raise ValueError(f"Cannot determine base_frequency with fewer than two base dates ({dates}).")
+        return frequency_to_timedelta(dates[1].astype(object) - dates[0].astype(object))
+
+    # ------------------------------------------------------------------
+    # Step axis
+    # ------------------------------------------------------------------
+
+    @property
+    def steps(self) -> NDArray[np.timedelta64]:
+        """Return the forecast steps."""
+        return self._steps
+
+    @property
+    def step_start(self) -> datetime.timedelta:
+        """Return the first forecast step."""
+        return self._steps[0].astype("timedelta64[s]").astype(datetime.timedelta)
+
+    @property
+    def step_end(self) -> datetime.timedelta:
+        """Return the last forecast step."""
+        return self._steps[-1].astype("timedelta64[s]").astype(datetime.timedelta)
+
+    @property
+    def step_frequency(self) -> datetime.timedelta | None:
+        """Return the step interval, or None if steps are not uniformly spaced."""
+        if len(self._steps) < 2:
+            return None
+        diffs = np.diff(self._steps)
+        if np.all(diffs == diffs[0]):
+            return diffs[0].astype("timedelta64[s]").astype(datetime.timedelta)
+        return None
+
+    # ------------------------------------------------------------------
+    # Envelope (valid-time range) and disabled single time axis
+    # ------------------------------------------------------------------
+
+    @property
+    def start_date(self) -> np.datetime64:
+        """Return the earliest valid time: first base date + first step."""
+        return self._base_dates[0] + self._steps[0]
+
+    @property
+    def end_date(self) -> np.datetime64:
+        """Return the latest valid time: last base date + last step."""
+        return self._base_dates[-1] + self._steps[-1]
+
+    @property
+    def dates(self) -> NDArray[np.datetime64]:
+        """Trajectories datasets do not have a single ``dates`` array."""
+        raise AttributeError(
+            "Trajectories datasets have two time axes. "
+            "Use 'base_dates' for analysis times and 'steps' for forecast lead times."
+        )
+
+    @property
+    def frequency(self) -> datetime.timedelta | None:
+        """Trajectories datasets have two frequencies, so ``frequency`` is None."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Missing base dates
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def missing(self) -> set[int]:
+        """Return base-date indices whose valid-time lookups hit a missing gridded row."""
+        gridded_missing = self.forward.missing
+        if not gridded_missing:
+            return set()
+        return {i for i in range(len(self)) if set(self._index_map[i].tolist()) & gridded_missing}
+
+    # ------------------------------------------------------------------
+    # Metadata
+    # ------------------------------------------------------------------
+
+    def statistics_tendencies(self, delta: datetime.timedelta | None = None) -> dict[str, NDArray[Any]]:
+        """Return the underlying gridded dataset's tendencies.
+
+        The broadcast gridded variables carry the gridded dataset's own
+        tendencies (computed along the gridded time axis at its own frequency).
+        The trajectory step-frequency ``delta`` propagated by the join does not
+        apply to them, so it is ignored and the gridded dataset's default is
+        used — this never raises for a lack of a step-frequency tendencies key.
+        """
+        return self.forward.statistics_tendencies()
+
+    def forwards_subclass_metadata_specific(self) -> dict[str, Any]:
+        return {"broadcast": "gridded_as_trajectory"}
+
+    def metadata_specific(self, **kwargs: Any) -> dict[str, Any]:
+        return super().metadata_specific(**trajectory_metadata(self), **kwargs)
+
+    def dataset_metadata(self) -> dict[str, Any]:
+        md = super().dataset_metadata()
+        md.update(trajectory_metadata(self))
+        return md
+
+    def tree(self) -> Node:
+        return Node(self, [self.forward.tree()])
+
+    def __repr__(self) -> str:
+        return f"GriddedAsTrajectory({self.forward})"

--- a/src/anemoi/datasets/usage/trajectories/join.py
+++ b/src/anemoi/datasets/usage/trajectories/join.py
@@ -68,7 +68,12 @@ class TrajectoryJoin(Join):
     """
 
     def __init__(self, datasets: list[Dataset], options: Options) -> None:
-        self._template = next(d for d in datasets if not isinstance(d, GriddedAsTrajectory))
+        self._template = next((d for d in datasets if not isinstance(d, GriddedAsTrajectory)), None)
+        if self._template is None:
+            raise ValueError(
+                f"{self.__class__.__name__} requires at least one trajectory member "
+                "(all members are broadcast-gridded)."
+            )
         super().__init__(datasets, options)
 
     # ------------------------------------------------------------------

--- a/src/anemoi/datasets/usage/trajectories/join.py
+++ b/src/anemoi/datasets/usage/trajectories/join.py
@@ -1,0 +1,170 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Overlay a mix of trajectory and gridded datasets along the variable axis.
+
+``open_dataset(traj, gridded, ...)`` (in any order, any number of each) is
+routed here whenever at least one argument is a trajectories dataset.  Each
+gridded dataset is broadcast onto the trajectory layout with
+:class:`GriddedAsTrajectory` (valid-time lookup), and all datasets are then
+joined along the variable axis, preserving the argument order.  The result
+behaves like a trajectories dataset.
+"""
+
+import datetime
+import logging
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from anemoi.datasets.usage.dataset import Dataset
+from anemoi.datasets.usage.gridded.join import Join
+from anemoi.datasets.usage.options import Options
+from anemoi.datasets.usage.trajectories.broadcast import GriddedAsTrajectory
+from anemoi.datasets.usage.trajectories.metadata import trajectory_metadata
+
+LOG = logging.getLogger(__name__)
+
+
+def is_trajectory(dataset: Dataset) -> bool:
+    """Return whether a dataset uses the 5-D trajectories layout.
+
+    Parameters
+    ----------
+    dataset : Dataset
+        The dataset to test.
+
+    Returns
+    -------
+    bool
+        True if the dataset has the 5-D trajectories layout.
+    """
+    return len(dataset.shape) == 5
+
+
+class TrajectoryJoin(Join):
+    """Join trajectory (and broadcast-gridded) datasets along the variable axis.
+
+    Reuses the whole gridded :class:`~anemoi.datasets.usage.gridded.join.Join`
+    data path (variable-axis concatenation is dimension-agnostic) and only
+    swaps the compatibility checks — which must compare ``base_dates`` and
+    ``steps`` rather than the single ``dates`` axis that trajectories do not
+    have — and the metadata, which follows the trajectory convention.
+
+    Parameters
+    ----------
+    datasets : list of Dataset
+        The datasets to join, in argument order.  Gridded members must already
+        be wrapped as :class:`GriddedAsTrajectory`.
+    options : Options
+        Options for the combined dataset.
+    """
+
+    def __init__(self, datasets: list[Dataset], options: Options) -> None:
+        self._template = next(d for d in datasets if not isinstance(d, GriddedAsTrajectory))
+        super().__init__(datasets, options)
+
+    # ------------------------------------------------------------------
+    # Compatibility (base_dates / steps instead of dates)
+    # ------------------------------------------------------------------
+
+    def check_compatibility(self, d1: Dataset, d2: Dataset) -> None:
+        """Check that two members share grid, base dates and steps."""
+        # Sub-shapes first: a clean "Incompatible shapes" message for a
+        # cell/ensemble/step-count mismatch, before check_same_grid compares
+        # (mismatched-length) coordinate arrays.
+        self.check_same_sub_shapes(d1, d2, drop_axis=1)
+        self.check_same_base_dates(d1, d2)
+        self.check_same_steps(d1, d2)
+        self.check_same_grid(d1, d2)
+
+    def check_same_base_dates(self, d1: Dataset, d2: Dataset) -> None:
+        """Raise if two members have different base dates."""
+        if not np.array_equal(d1.base_dates, d2.base_dates):
+            raise ValueError(
+                f"{self.__class__.__name__}: Incompatible base dates: "
+                f"{d1.base_dates[0]}..{d1.base_dates[-1]} and {d2.base_dates[0]}..{d2.base_dates[-1]} ({d1} {d2})"
+            )
+
+    def check_same_steps(self, d1: Dataset, d2: Dataset) -> None:
+        """Raise if two members have different steps."""
+        if not np.array_equal(d1.steps, d2.steps):
+            raise ValueError(f"{self.__class__.__name__}: Incompatible steps: {d1.steps} and {d2.steps} ({d1} {d2})")
+
+    # ------------------------------------------------------------------
+    # Operation dispatch and date filtering (delegated to a real trajectory)
+    # ------------------------------------------------------------------
+
+    def usage_factory_load(self, name: str) -> Any:
+        """Resolve operations from the trajectories package via a real trajectory member."""
+        return self._template.usage_factory_load(name)
+
+    def _dates_to_indices(self, start: Any, end: Any) -> list[int]:
+        """Use the trajectory envelope filtering of the template member.
+
+        The template shares the join's base dates and steps, so its base-date
+        indices apply unchanged to the join.
+        """
+        return self._template._dates_to_indices(start, end)
+
+    def _frequency_to_indices(self, frequency: str) -> list[int]:
+        """The ``frequency`` option is not supported for trajectories (delegated)."""
+        return self._template._frequency_to_indices(frequency)
+
+    # ------------------------------------------------------------------
+    # Metadata (trajectory convention)
+    # ------------------------------------------------------------------
+
+    def statistics_tendencies(self, delta: datetime.timedelta | None = None) -> dict[str, NDArray[Any]]:
+        """Return joined statistics tendencies, defaulting the delta to the step frequency."""
+        if delta is None:
+            delta = self.step_frequency
+            if delta is None:
+                raise ValueError(
+                    "Cannot use a default tendencies delta: the steps of this dataset "
+                    "are not uniformly spaced. Pass 'delta' explicitly."
+                )
+        return super().statistics_tendencies(delta)
+
+    def metadata_specific(self, **kwargs: Any) -> dict[str, Any]:
+        return super().metadata_specific(**trajectory_metadata(self), **kwargs)
+
+    def dataset_metadata(self) -> dict[str, Any]:
+        md = super().dataset_metadata()
+        md.update(trajectory_metadata(self))
+        return md
+
+
+def trajectory_join(datasets: list[Dataset], options: Options) -> Dataset:
+    """Build a :class:`TrajectoryJoin` from a mix of trajectory and gridded datasets.
+
+    Parameters
+    ----------
+    datasets : list of Dataset
+        The opened datasets, in argument order.  At least one must be a
+        trajectories dataset.
+    options : Options
+        Options for the combined dataset.
+
+    Returns
+    -------
+    Dataset
+        The joined dataset, behaving like a trajectories dataset.
+    """
+    template = next((d for d in datasets if is_trajectory(d)), None)
+    if template is None:
+        raise ValueError("trajectory_join requires at least one trajectories dataset")
+
+    base_dates = template.base_dates
+    steps = template.steps
+
+    members = [d if is_trajectory(d) else GriddedAsTrajectory(d, base_dates, steps) for d in datasets]
+
+    return TrajectoryJoin(members, options)

--- a/tests/test_trajectories_mix.py
+++ b/tests/test_trajectories_mix.py
@@ -1,0 +1,287 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Tests for overlaying gridded datasets onto trajectories datasets.
+
+``open_dataset(traj, gridded)`` (in any order, any number of each) broadcasts
+every gridded dataset onto the trajectory layout by valid-time lookup
+(``result[base=b, step=s] = gridded[b + s]``) and joins them along the variable
+axis, preserving the argument order.  The result behaves like a trajectories
+dataset.
+"""
+
+import datetime
+
+import numpy as np
+import pytest
+import zarr
+from test_trajectories import make_trajectories_zarr
+
+from anemoi.datasets import open_dataset
+from anemoi.datasets.usage.store import ZarrStore
+
+N_CELLS = 10
+
+
+def make_gridded_zarr(
+    n_dates: int,
+    n_vars: int = 2,
+    n_cells: int = N_CELLS,
+    frequency_h: int = 6,
+    start: datetime.datetime = datetime.datetime(2021, 1, 1),
+    vars: list[str] | None = None,
+    analytic: bool = True,
+) -> zarr.Group:
+    """Build a minimal in-memory zarr group with the gridded layout.
+
+    The grid (``latitudes``/``longitudes``) matches
+    :func:`test_trajectories.make_trajectories_zarr` so the two can be joined.
+
+    Parameters
+    ----------
+    n_dates : int
+        Number of dates.
+    n_vars : int
+        Number of variables.
+    n_cells : int
+        Number of grid cells.
+    frequency_h : int
+        Dataset frequency in hours.
+    start : datetime.datetime
+        First date.
+    vars : list of str, optional
+        Variable names.  Defaults to ``["g0", "g1", ...]``.
+    analytic : bool
+        When True, fill ``data`` with ``arange`` values so every element is
+        unique and valid-time lookups can be checked exactly.
+
+    Returns
+    -------
+    zarr.Group
+        In-memory zarr group.
+    """
+    if vars is None:
+        vars = [f"g{i}" for i in range(n_vars)]
+
+    root = zarr.group()
+    dates = np.array(
+        [start + datetime.timedelta(hours=frequency_h * i) for i in range(n_dates)],
+        dtype="datetime64[s]",
+    )
+    shape = (n_dates, n_vars, 1, n_cells)
+    if analytic:
+        data = np.arange(np.prod(shape), dtype="float64").reshape(shape)
+    else:
+        data = np.random.default_rng(1).random(shape)
+
+    root.create_array("data", data=data, chunks=data.shape, compressors=None)
+    root.create_array("dates", data=dates, compressors=None)
+    root.create_array("latitudes", data=np.linspace(-90, 90, n_cells), compressors=None)
+    root.create_array("longitudes", data=np.linspace(0, 360, n_cells), compressors=None)
+    root.create_array("mean", data=np.mean(data, axis=(0, 2, 3)), compressors=None)
+    root.create_array("stdev", data=np.std(data, axis=(0, 2, 3)), compressors=None)
+    root.create_array("maximum", data=np.max(data, axis=(0, 2, 3)), compressors=None)
+    root.create_array("minimum", data=np.min(data, axis=(0, 2, 3)), compressors=None)
+
+    # Tendencies along the gridded time axis, keyed by the gridded frequency.
+    tendencies = np.diff(data, axis=0) if data.shape[0] >= 2 else data
+    for k, v in {
+        "mean": np.mean(tendencies, axis=(0, 2, 3)),
+        "stdev": np.std(tendencies, axis=(0, 2, 3)),
+        "maximum": np.max(tendencies, axis=(0, 2, 3)),
+        "minimum": np.min(tendencies, axis=(0, 2, 3)),
+    }.items():
+        root.create_array(f"statistics_tendencies_{frequency_h}h_{k}", data=v, compressors=None)
+
+    root.attrs["layout"] = "gridded"
+    root.attrs["frequency"] = f"{frequency_h}h"
+    root.attrs["resolution"] = "test"
+    root.attrs["name_to_index"] = {v: i for i, v in enumerate(vars)}
+    root.attrs["variables_metadata"] = {v: {} for v in vars}
+    root.attrs["data_request"] = {"grid": 1, "area": "g", "param_level": {}}
+    return root
+
+
+def _open(group: zarr.Group, path: str) -> ZarrStore:
+    return ZarrStore.from_group(group, path=path)
+
+
+def _add_statistics(group: zarr.Group, step_frequency_h: int = 6) -> zarr.Group:
+    """Add per-variable statistics arrays (missing from the shared helper)."""
+    data = group["data"][:]
+    # Reduce over every axis except variables (axis 1) -> shape (n_vars,).
+    axes = (0, 2, 3, 4)
+    group.create_array("mean", data=np.mean(data, axis=axes), compressors=None)
+    group.create_array("stdev", data=np.std(data, axis=axes), compressors=None)
+    group.create_array("maximum", data=np.max(data, axis=axes), compressors=None)
+    group.create_array("minimum", data=np.min(data, axis=axes), compressors=None)
+
+    # Tendencies along the step axis (position -2), keyed by the step frequency.
+    tendencies = np.diff(data, axis=-2)
+    for k, v in {
+        "mean": np.mean(tendencies, axis=axes),
+        "stdev": np.std(tendencies, axis=axes),
+        "maximum": np.max(tendencies, axis=axes),
+        "minimum": np.min(tendencies, axis=axes),
+    }.items():
+        group.create_array(f"statistics_tendencies_{step_frequency_h}h_{k}", data=v, compressors=None)
+    return group
+
+
+@pytest.fixture
+def traj():
+    # base dates: 2021-01-01 00/06/12/18Z ; steps: 6..30h
+    group = make_trajectories_zarr(n_dates=4, n_steps=5, n_vars=3, n_cells=N_CELLS, analytic=True)
+    return _open(_add_statistics(group), "traj.zarr")
+
+
+@pytest.fixture
+def gridded():
+    # 6h dataset covering the full valid-time envelope (up to 18Z + 30h = 48h)
+    return _open(make_gridded_zarr(n_dates=9, n_vars=2), "grid.zarr")
+
+
+def test_shape_and_variable_order(traj, gridded):
+    """Trajectory-first and gridded-first give the expected shape and variable order."""
+    ds = open_dataset(traj, gridded)
+    # (base_dates, Vt + Vg, ensembles, steps, cells)
+    assert ds.shape == (4, 5, 1, 5, N_CELLS)
+    assert ds.variables == ["a", "b", "c", "g0", "g1"]
+
+    reversed_ds = open_dataset(gridded, traj)
+    assert reversed_ds.shape == (4, 5, 1, 5, N_CELLS)
+    assert reversed_ds.variables == ["g0", "g1", "a", "b", "c"]
+
+
+def test_behaves_like_trajectory(traj, gridded):
+    """The result exposes the trajectory time axes, not a single ``dates`` axis."""
+    ds = open_dataset(traj, gridded)
+    assert ds.frequency is None
+    assert np.array_equal(ds.base_dates, traj.base_dates)
+    assert np.array_equal(ds.steps, traj.steps)
+    assert ds.base_frequency == datetime.timedelta(hours=6)
+    with pytest.raises(AttributeError):
+        _ = ds.dates
+
+
+def test_valid_time_broadcast_values(traj, gridded):
+    """Each gridded slot equals the gridded field at valid time ``base + step``."""
+    ds = open_dataset(traj, gridded)
+    full = ds[:]
+
+    gridded_dates = gridded.dates.astype("datetime64[s]")
+    lookup = {d: i for i, d in enumerate(gridded_dates.tolist())}
+    base_dates = traj.base_dates.astype("datetime64[s]")
+    steps = traj.steps.astype("timedelta64[s]")
+    gdata = gridded[:]
+    n_traj_vars = len(traj.variables)
+
+    for i in range(len(base_dates)):
+        for j in range(len(steps)):
+            k = lookup[(base_dates[i] + steps[j]).tolist()]
+            # Trajectory variables are untouched; gridded variables broadcast.
+            assert np.array_equal(full[i, :n_traj_vars, :, j, :], traj[i][:, :, j, :])
+            assert np.array_equal(full[i, n_traj_vars:, :, j, :], gdata[k])
+
+
+def test_duplication_on_shared_valid_time(traj, gridded):
+    """The same gridded field is reused wherever two (base, step) pairs share a valid time."""
+    ds = open_dataset(traj, gridded)
+    full = ds[:]
+    n_traj_vars = len(traj.variables)
+
+    # base[0]=00Z, step 12h -> valid 12Z ; base[2]=12Z, step 0h is absent, but
+    # base[1]=06Z + 6h -> 12Z and base[0]=00Z + 12h -> 12Z share valid time 12Z.
+    assert np.array_equal(
+        full[0, n_traj_vars:, :, 1, :],  # base 00Z, step 12h (index 1)
+        full[1, n_traj_vars:, :, 0, :],  # base 06Z, step 6h  (index 0)
+    )
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        (1,),
+        (1, slice(None), 0, 2, slice(None)),
+        (slice(1, 3), slice(3, 5)),
+        (slice(0, 2),),
+    ],
+)
+def test_indexing_matches_full(traj, gridded, index):
+    """Tuple/slice indexing matches indexing the materialised array."""
+    ds = open_dataset(traj, gridded)
+    full = ds[:]
+    assert np.array_equal(ds[index], full[index])
+
+
+def test_statistics_are_joined(traj, gridded):
+    """Statistics are concatenated along the variable axis in argument order."""
+    ds = open_dataset(traj, gridded)
+    for key in ("mean", "stdev", "maximum", "minimum"):
+        expected = np.concatenate([traj.statistics[key], gridded.statistics[key]], axis=0)
+        assert np.array_equal(ds.statistics[key], expected)
+
+
+def test_statistics_tendencies_forwarded(traj, gridded):
+    """Tendencies do not raise; the gridded variables carry the gridded dataset's own values."""
+    ds = open_dataset(traj, gridded)
+    n_traj_vars = len(traj.variables)
+
+    tendencies = ds.statistics_tendencies()  # must not raise
+    for key in ("mean", "stdev", "maximum", "minimum"):
+        # Trajectory part uses the step-frequency delta; gridded part is forwarded verbatim.
+        assert np.array_equal(tendencies[key][:n_traj_vars], traj.statistics_tendencies()[key])
+        assert np.array_equal(tendencies[key][n_traj_vars:], gridded.statistics_tendencies()[key])
+
+
+def test_select_after_join(traj, gridded):
+    """A ``select`` mixing trajectory and gridded variables keeps the trajectory layout."""
+    ds = open_dataset(traj, gridded, select=["a", "g1"])
+    assert ds.variables == ["a", "g1"]
+    assert ds.shape == (4, 2, 1, 5, N_CELLS)
+
+
+def test_step_subset_after_join(traj, gridded):
+    """A ``steps`` selection narrows the step axis of the joined dataset."""
+    ds = open_dataset(traj, gridded, steps=[6, 18])
+    assert ds.shape[-2] == 2
+    assert [s.astype("timedelta64[h]").astype(int) for s in ds.steps] == [6, 18]
+
+
+def test_metadata_serialises(traj, gridded):
+    """``metadata()`` is JSON-serialisable and carries the trajectory keys."""
+    ds = open_dataset(traj, gridded)
+    md = ds.metadata()
+    assert md["frequency"] is None
+    assert md["base_frequency"] == "6h"
+    assert "specific" in md
+
+
+def test_missing_valid_time_raises(traj):
+    """A gridded dataset that does not cover every required valid time is rejected."""
+    # Only three 6h dates -> covers 00/06/12Z, far short of the 48h envelope.
+    short = _open(make_gridded_zarr(n_dates=3, n_vars=2), "short.zarr")
+    with pytest.raises(ValueError, match="does not cover"):
+        open_dataset(traj, short)
+
+
+def test_grid_mismatch_raises(traj):
+    """A gridded dataset on a different grid is rejected."""
+    other_grid = _open(make_gridded_zarr(n_dates=9, n_vars=2, n_cells=N_CELLS + 1), "other.zarr")
+    with pytest.raises(ValueError):
+        open_dataset(traj, other_grid)
+
+
+def test_multiple_gridded(traj):
+    """Any number of gridded datasets can be overlaid onto a trajectory."""
+    g1 = _open(make_gridded_zarr(n_dates=9, n_vars=1, vars=["x"]), "g1.zarr")
+    g2 = _open(make_gridded_zarr(n_dates=9, n_vars=2, vars=["y", "z"]), "g2.zarr")
+    ds = open_dataset(traj, g1, g2)
+    assert ds.variables == ["a", "b", "c", "x", "y", "z"]
+    assert ds.shape == (4, 6, 1, 5, N_CELLS)

--- a/tests/test_trajectories_mix.py
+++ b/tests/test_trajectories_mix.py
@@ -14,6 +14,18 @@ every gridded dataset onto the trajectory layout by valid-time lookup
 (``result[base=b, step=s] = gridded[b + s]``) and joins them along the variable
 axis, preserving the argument order.  The result behaves like a trajectories
 dataset.
+
+Notes
+-----
+
+TO BE REFACTORED. These tests hand-build in-memory zarr groups
+(``make_trajectories_zarr`` + a local ``_add_statistics`` workaround and a
+local ``make_gridded_zarr``) because synthetic datasets do not yet support
+the trajectories layout. Once synthetic datasets gain a trajectories layout,
+the fixtures here should most likely be rebuilt on top of them, folding the
+statistics/tendencies generation into the shared helpers and reusing the
+canonical indexing sweep (``anemoi.datasets.misc.testing`` /
+``default_test_indexing``) instead of the bespoke helpers below.
 """
 
 import datetime


### PR DESCRIPTION
Allows `open_dataset(traj, gridded, ...)` — any mix, any order — now broadcasts each gridded dataset onto the trajectory layout by valid-time lookup (result[base=b, step=s] = gridded[b+s]) and joins them along the variable axis, preserving argument order. The result behaves like a trajectories dataset.


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
