### PR TITLE
feat: fix timezone corner case

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ dynamic = [
 ]
 dependencies = [
   "anemoi-transform>=0.4",
-  "anemoi-utils[s3]>=0.5",
+  "anemoi-utils[s3]>=0.5.12",
   "cfunits",
   "glom",
   "jsonschema",
   "lru-dict",
-  "numcodecs<0.16",        # Until we move to zarr3
+  "numcodecs<0.16",           # Until we move to zarr3
   "numpy",
   "pint",
   "psutil",

--- a/src/anemoi/datasets/create/recipe/dates.py
+++ b/src/anemoi/datasets/create/recipe/dates.py
@@ -40,6 +40,16 @@ Frequency = Annotated[
     PlainSerializer(frequency_to_string, return_type=str, when_used="json"),
 ]
 
+# A datetime normalised to naive-UTC on input, via ``as_datetime``: an
+# explicitly-offset value (``Z``, ``+02:00``) is converted through its own
+# offset, a naive value is taken as UTC as-is. Every recipe date is put on
+# the same naive convention regardless of which YAML construct wrote it
+# (top-level ``dates``, a ``concat``/``pipe`` block's ``dates``,
+# ``base_dates``). Without this, a stray ``Z`` in a block's ``dates`` yields
+# a tz-aware datetime that never compares equal to the naive top-level dates,
+# so ``concat``/``join`` date-set matching silently finds nothing.
+NaiveDatetime = Annotated[datetime.datetime, BeforeValidator(as_datetime)]
+
 
 def _extend(x: str | list[Any] | tuple[Any, ...]) -> Iterator[datetime.datetime]:
     """Extend a date range or list of dates into individual datetime objects.
@@ -111,12 +121,12 @@ class DatesProvider(BaseModel):
 class StartEndDates(DatesProvider):
 
     class MissingRange(BaseModel):
-        start: datetime.datetime
-        end: datetime.datetime
+        start: NaiveDatetime
+        end: NaiveDatetime
         frequency: Frequency | None = None
 
-    start: datetime.datetime
-    end: datetime.datetime
+    start: NaiveDatetime
+    end: NaiveDatetime
     frequency: Frequency = frequency_to_timedelta("1h")
     missing: list[datetime.datetime | str | MissingRange] = Field(default_factory=list)
 

--- a/src/anemoi/datasets/misc/dumper.py
+++ b/src/anemoi/datasets/misc/dumper.py
@@ -19,10 +19,14 @@ LOG = logging.getLogger(__name__)
 def represent_date(dumper, data):
 
     if isinstance(data, datetime.datetime):
-        if data.tzinfo is None:
-            data = data.replace(tzinfo=datetime.UTC)
-        data = data.astimezone(datetime.UTC)
-        iso_str = data.replace(tzinfo=None).isoformat(timespec="seconds") + "Z"
+        if data.tzinfo is not None:
+            # Only an explicitly-offset datetime may be converted: the shift
+            # is a pure function of its own offset, not of the local clock.
+            # A naive datetime already means UTC by convention and is left
+            # exactly as written, so the dump stays reproducible across
+            # machines and no timezone is invented.
+            data = data.astimezone(datetime.UTC).replace(tzinfo=None)
+        iso_str = data.isoformat(timespec="seconds")
     else:
         iso_str = data.isoformat()
 


### PR DESCRIPTION
*(ai-assisted)* _I found the issue when updating the script to write anemoi-datasets recipe, when writing dates, I had a confusion between timezone aware and timezone-unware(i.e. naive) dates.
Claude generated a fix and a draft of the message below._


 **I reviewed this, it fixes my issue and makes sense to me and is in line with the current way anemoi-datasets process timezone-aware dates..**


## Symptom

  `anemoi-datasets create` on a recipe with `concat`/`pipe` blocks fails at  `init` with:

  AssertionError: join: No results to join

  This bites recipes produced by my updated version of `anemoi-datasets recipe --migrate` (which   rewrites plain quoted dates like `'1979-01-01T00:00:00'` into `Z`-suffixed  timestamps), and equally any hand-written recipe that puts a `Z` in a block's  `dates:`.

 ## Root cause

  Two code paths disagreed on whether a recipe date is timezone-aware:

  - The top-level `dates:` group is stripped to **naive** in
    `GroupOfDates.__init__` (via `as_datetime`).
  - A `concat`/`pipe` block's `dates:` (`StartEndDates.start`/`.end`) were parsed    straight by pydantic and kept whatever tzinfo the string carried — **aware**    when the string ended in `Z`.

  `matching_dates` does `set(group) & set(block)`; naive vs. aware datetimes of  the same instant never compare equal, so every block matched zero dates and  `join([])` asserted.

  Separately, `misc/dumper.py::represent_date` treated **every** datetime as UTC  and appended `Z`, so `--format`/`--migrate` silently rewrote a naive  `'...T00:00:00'` into an aware `...T00:00:00Z` — manufacturing the very tzinfo  that then broke matching, and making the dump machine-dependent.

  ## Fix

  1. **`create/recipe/dates.py`** — new `NaiveDatetime` annotated type     (`BeforeValidator(as_datetime)`, mirroring the existing `Frequency`     pattern), applied to `StartEndDates`/`BaseDates` `start`/`end` (and the
     inner `MissingRange`). Every recipe date is now normalised to naive-UTC on     input, regardless of which YAML construct wrote it.  

2. **`misc/dumper.py`** — `represent_date` leaves naive datetimes exactly as      written (no forged `Z`) and only converts genuinely offset-aware values     through their own offset. Output no longer depends on the machine's `$TZ`.

  Together these make `GroupOfDates`'s own `as_datetime` call a redundant no-op  and the set-intersection in `matching_dates` just work — for migrated,  hand-written, and generated recipes alike.



***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
