### PR TITLE
fix: fix issue 718

### DIFF
--- a/src/anemoi/datasets/commands/copy.py
+++ b/src/anemoi/datasets/commands/copy.py
@@ -417,7 +417,11 @@ class ZarrCopier:
         data = source[name][...]
         if name in target:
             del target[name]
-        target.create_array(name, data=data)
+        # These are small coordinate/dimension arrays (e.g. latitudes, longitudes,
+        # dates). Store each as a single chunk so the chunking does not depend on
+        # zarr's automatic guess, which can produce a partial final chunk for large
+        # arrays and later trip the divisibility check in check_zarr (see #718).
+        target.create_array(name, data=data, chunks=data.shape)
         LOG.info(f"Copied {name}")
 
     def children(self, group):

--- a/src/anemoi/datasets/misc/check.py
+++ b/src/anemoi/datasets/misc/check.py
@@ -64,8 +64,9 @@ def _check_array(array, verbosity: int, *path) -> None:
 
     else:
         # zarr v2: dot-separated chunk files directly in the array directory.
-        assert math.prod(array.shape) % math.prod(array.chunks) == 0
-        file_count = math.prod(array.shape) // math.prod(array.chunks)
+        # ceil division per dimension: a partial final chunk is valid zarr, so the
+        # shape need not be an exact multiple of the chunk size (see #718).
+        file_count = math.prod(-(-s // c) for s, c in zip(array.shape, array.chunks))
 
         chunks = array.chunks
         count = 0


### PR DESCRIPTION
(ai-generated) I reviewed the code, LGTM.


## Root cause:

 copy_array (copy.py:420) copied the auxiliary 1-D arrays (latitudes, longitudes, dates, …) with target.create_array(name, data=data) and no
  chunks. Zarr then auto-guesses a chunk size against a byte budget (~256 KB). For latitudes of shape (38009,) (≈297 KB) it halves the array to
  chunks (19005,), leaving a valid-but-partial final chunk. The zarr-v2 branch of check_zarr (check.py:67) asserts the shape is evenly divisible by
  the chunk, so it aborts. It only bites when the array is large enough to be split (and the length doesn't divide evenly), which is exactly "large,
  odd number of grid points". The main data array is unaffected because copy_data sets its chunks explicitly.


## fix

  Pass chunks=data.shape when creating these arrays, so each small coordinate/dimension array is stored as a single chunk — the chunk count then
  always divides the shape, and the copy no longer depends on zarr's automatic guess:

  target.create_array(name, data=data, chunks=data.shape)


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
