### PR TITLE
fix: repair tendency statistics across group boundaries

### DIFF
--- a/src/anemoi/datasets/create/statistics.py
+++ b/src/anemoi/datasets/create/statistics.py
@@ -208,9 +208,7 @@ class _TendencyCollector(_CollectorBase):
         # Number of dates at the start that couldn't have tendencies computed
         # A "missing" date d means we could not compute value(d) - value(d - delta)
         # because d - delta is before available data.
-        # The first delta dates of the entire (filtered) dataset are permanently missing:
-        # there's no data before them, so their tendencies can never be computed.
-        # This is set once on the first update call and not changed afterwards.
+        # This is updated as more dates are seen, until it reaches delta.
         self._n_missing = None
 
     def __repr__(self, extra: str = ""):
@@ -262,11 +260,9 @@ class _TendencyCollector(_CollectorBase):
             tendencies = combined[self._delta :] - combined[: -self._delta]
             _CollectorBase.update(self, tendencies)
 
-        # Track date summary and offset (only on first call do we set n_missing and offset)
+        # Track date summary and offset
         if self._first_date is None and len(dates) > 0:
             self._first_date = dates[0]
-            # On first call, the missing count is min(delta, number of dates in first batch)
-            self._n_missing = min(self._delta, len(dates))
             # Compute offset from group start to first filtered date
             if first_offset_in_batch is not None:
                 self._first_date_offset = self._unfiltered_dates_seen + first_offset_in_batch
@@ -274,6 +270,7 @@ class _TendencyCollector(_CollectorBase):
         if len(dates) > 0:
             self._last_date = dates[-1]
         self._n_dates += len(dates)
+        self._n_missing = min(self._delta, self._n_dates)
 
         # Track unfiltered dates for offset computation across batches
         if unfiltered_batch_size is not None:

--- a/tests/create/test_statistics.py
+++ b/tests/create/test_statistics.py
@@ -426,6 +426,39 @@ def test_serialisation():
     compare_constants(c_constants, c2.constant_variables())
 
 
+def test_merge_tendencies_with_batches_smaller_than_delta():
+    """Check that no tendencies are missed when the data is split into parts."""
+    n_dates = 30
+    partition = 15
+    delta = 6
+    dates = np.arange(n_dates).astype(float)
+    data = np.square(dates)[:, None]
+    filter = StatisticsFilter(dates[0], dates[-1])
+    tendencies = {"delta_6": delta}
+
+    c0 = StatisticsCollector(variables_names=["a"], tendencies=tendencies, filter=filter)
+    for i in range(n_dates):
+        c0.collect(data[i : i + 1], dates[i : i + 1])
+    c0_stats = deepcopy(c0.statistics())
+
+    c1 = StatisticsCollector(variables_names=["a"], tendencies=tendencies, filter=filter)
+    c2 = StatisticsCollector(variables_names=["a"], tendencies=tendencies, filter=filter)
+
+    for i in range(partition):
+        c1.collect(data[i : i + 1], dates[i : i + 1])
+    for i in range(partition, n_dates):
+        c2.collect(data[i : i + 1], dates[i : i + 1])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path1 = f"{tmpdir}/collector1.pkl"
+        path2 = f"{tmpdir}/collector2.pkl"
+        c1.serialise(path1, group=0, start=0, end=partition)
+        c2.serialise(path2, group=1, start=partition, end=n_dates)
+        reloaded = StatisticsCollector.load_precomputed(DatasetMock(data, dates), [path1, path2])
+
+    compare_statistics(reloaded.statistics(), c0_stats)
+
+
 @pytest.mark.parametrize(
     "deltas",
     [


### PR DESCRIPTION
This fixes a problem where some time differences were left out when data was read in small batches and split into separate parts. A test was added to check that split data gives the same result as reading it continuously.
