### PR TITLE
feat: output zarr when recomputing statistics

### DIFF
--- a/docs/cli/compute.rst
+++ b/docs/cli/compute.rst
@@ -174,18 +174,6 @@ low-resolution grid and the native low-resolution dataset:
 
     anemoi-datasets compute hi-res grid=o96 --statistics-residual lo-res
 
-Use the residual statistics as an override when opening a dataset for training:
-
-.. code-block:: bash
-
-    anemoi-datasets compute hi-res grid=o96 --statistics-residual lo-res --statistics-tendencies 6h
-    # → produces hi-res.statistics.zarr
-
-.. code:: python
-
-    ds = open_dataset("hi-res",
-                      statistics_tendencies="hi-res.statistics.zarr")
-
 Resume a long run that was interrupted:
 
 .. code-block:: bash

--- a/docs/cli/compute.rst
+++ b/docs/cli/compute.rst
@@ -29,7 +29,7 @@ Synopsis
         [--statistics] [--statistics-tendencies 6h] \
         [--statistics-residual <dataset-2>] \
         [--chunk-size N] [--sample-dates FRACTION] [--compare] \
-        [--output FILE.json] [--overwrite] [--checkpoint PATH] [--resume] [--parallel N]
+        [--output FILE.zarr] [--overwrite] [--checkpoint PATH] [--resume] [--parallel N]
 
 While the command runs it shows a progress bar and, in an interactive terminal,
 refreshes a statistics table (the same columns as ``inspect``) for all variables
@@ -97,14 +97,23 @@ Options
     stored ``statistics`` / ``statistics_tendencies(delta)`` and print the
     absolute and relative differences. Not applicable to ``--statistics-residual``.
 
-``--output FILE.json``
-    Write the results (and any ``--compare`` differences) to this JSON file. NaNs
-    are written as ``null``. Results are always written: without ``--output`` the
-    default path is ``<dataset-name>.statistics.json`` in the current directory.
+``--output FILE.zarr``
+    Write the results to this zarr store. The store contains the statistics
+    arrays under the keys expected by :func:`open_dataset` (``mean``,
+    ``stdev``, ``maximum``, ``minimum`` for plain statistics;
+    ``statistics_tendencies_{delta}_{key}`` for tendency statistics). It can
+    therefore be passed directly to :func:`open_dataset` as the ``statistics``
+    or ``statistics_tendencies`` keyword argument::
+
+        ds = open_dataset("my-dataset",
+                          statistics_tendencies="residuals.statistics.zarr")
+
+    Results are always written: without ``--output`` the default path is
+    ``<dataset-name>.statistics.zarr`` in the current directory.
 
 ``--overwrite``
-    Replace the output file if it already exists. Without it the command fails
-    immediately (before computing anything) when the output file is present.
+    Replace the output store if it already exists. Without it the command fails
+    immediately (before computing anything) when the output store is present.
 
 ``--parallel N``
     Compute using ``N`` worker processes. The time range is split into segments
@@ -133,11 +142,11 @@ Recompute the statistics of a dataset as opened over a sub-period:
 
     anemoi-datasets compute my-dataset start=2020-01-01 end=2020-12-31 --statistics
 
-Compute 6-hour tendency statistics in parallel and save to JSON:
+Compute 6-hour tendency statistics in parallel and save to a zarr store:
 
 .. code-block:: bash
 
-    anemoi-datasets compute my-dataset --statistics-tendencies 6h --parallel 8 --output tend.json
+    anemoi-datasets compute my-dataset --statistics-tendencies 6h --parallel 8 --output tend.zarr
 
 Estimate statistics quickly from 10% of the dates:
 
@@ -164,6 +173,18 @@ low-resolution grid and the native low-resolution dataset:
 .. code-block:: bash
 
     anemoi-datasets compute hi-res grid=o96 --statistics-residual lo-res
+
+Use the residual statistics as an override when opening a dataset for training:
+
+.. code-block:: bash
+
+    anemoi-datasets compute hi-res grid=o96 --statistics-residual lo-res --statistics-tendencies 6h
+    # → produces hi-res.statistics.zarr
+
+.. code:: python
+
+    ds = open_dataset("hi-res",
+                      statistics_tendencies="hi-res.statistics.zarr")
 
 Resume a long run that was interrupted:
 

--- a/src/anemoi/datasets/commands/compute/__init__.py
+++ b/src/anemoi/datasets/commands/compute/__init__.py
@@ -452,7 +452,7 @@ def _write_zarr(
     if overwrite and os.path.exists(output):
         shutil.rmtree(output)
 
-    store = zarr.open_group(store=zarr.DirectoryStore(output), mode="w")
+    store = zarr.open(output, mode="w")
     n = len(variables)
 
     # Minimal attrs so that open_dataset recognises this as a gridded store.

--- a/src/anemoi/datasets/commands/compute/__init__.py
+++ b/src/anemoi/datasets/commands/compute/__init__.py
@@ -424,13 +424,14 @@ def _write_zarr(
     results: dict[str, Any],
     tendency: str | None,
     overwrite: bool,
+    dates: "np.ndarray | None" = None,
 ) -> None:
     """Write statistics results to a minimal zarr store compatible with ``open_dataset``.
 
-    The store contains only the arrays needed for use as a ``statistics`` or
-    ``statistics_tendencies`` override in ``open_dataset``. It has no ``data``
-    array and no ``dates`` array, so it cannot be iterated; it exists only to
-    serve ``statistics`` and ``statistics_tendencies`` look-ups.
+    The store contains the arrays needed for use as a ``statistics`` or
+    ``statistics_tendencies`` override in ``open_dataset``. A ``dates`` array
+    is required by ``metadata_specific()`` when the store is used as an override;
+    pass the source dataset's dates so that metadata round-trips correctly.
 
     Parameters
     ----------
@@ -445,6 +446,10 @@ def _write_zarr(
         names expected by ``GriddedZarr.statistics_tendencies``.
     overwrite : bool
         If ``True``, remove an existing store before writing.
+    dates : np.ndarray or None
+        Dates from the source dataset. Written into the store so that
+        ``metadata_specific()`` (called during training) can read ``start_date``
+        and ``end_date`` without raising ``KeyError: 'dates'``.
     """
     from anemoi.utils.dates import frequency_to_string
     from anemoi.utils.dates import frequency_to_timedelta
@@ -464,6 +469,17 @@ def _write_zarr(
     # 1 grid point.  open_dataset needs this to exist but never reads values from it
     # when the store is used solely as a statistics source.
     store.create_dataset("data", shape=(0, n, 1, 1), dtype="float32")
+
+    # dates is required by metadata_specific() → start_date / end_date.
+    if dates is not None:
+        store.create_dataset("dates", data=dates)
+        # frequency is derived from dates in GriddedZarr if not set explicitly,
+        # but storing it avoids a potentially expensive inference on a 1-date store.
+        if len(dates) >= 2:
+            from anemoi.utils.dates import frequency_to_string
+
+            delta = dates[1].astype(object) - dates[0].astype(object)
+            store.attrs["frequency"] = frequency_to_string(delta)
 
     if results["statistics"] is not None:
         for key in STATISTICS:
@@ -573,7 +589,10 @@ class Compute(Command):
         if parsed.compare:
             self._compare(parsed, variables, results)
 
-        _write_zarr(output, variables, results, parsed.tendency, parsed.overwrite)
+        from anemoi.datasets import open_dataset as _open_dataset
+
+        _ds = _open_dataset(*parsed.open_args, **parsed.open_kwargs)
+        _write_zarr(output, variables, results, parsed.tendency, parsed.overwrite, dates=_ds.dates)
         LOG.info("Results written to %s", output)
 
     def _compare(self, parsed: "_Parsed", variables: list[str], results: dict[str, Any]) -> None:

--- a/src/anemoi/datasets/commands/compute/__init__.py
+++ b/src/anemoi/datasets/commands/compute/__init__.py
@@ -21,12 +21,14 @@ Usage
     anemoi-datasets compute <dataset> [key=value ...] \\
         [--statistics] [--statistics-tendencies 6h] \\
         [--statistics-residual <dataset-2> [key=value ...]] \\
-        [--chunk-size N] [--compare] [--output FILE.json] [--overwrite] \\
+        [--chunk-size N] [--compare] [--output FILE.zarr] [--overwrite] \\
         [--checkpoint PATH] [--resume] [--parallel N]
 
-Results are always written to a JSON file. Without ``--output`` the default is
-``<dataset-name>.statistics.json`` in the current directory. The command fails if
-the output file already exists unless ``--overwrite`` is given.
+Results are always written to a zarr store. Without ``--output`` the
+default is ``<dataset-name>.statistics.zarr`` in the current directory. The
+command fails if the output store already exists unless ``--overwrite`` is
+given. The store can be passed directly to ``open_dataset`` as the
+``statistics`` or ``statistics_tendencies`` keyword argument.
 
 ``<dataset>`` is either a name/path followed by ``key=value`` ``open_dataset``
 options (e.g. ``start=2020-01-01 end=2020-12-31``), or a single JSON literal that
@@ -43,10 +45,12 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import sys
 from typing import Any
 
 import numpy as np
+import zarr
 
 from .. import Command
 from .engine import Task
@@ -178,7 +182,7 @@ def _short(obj: Any) -> str:
 
 
 def _default_output(parsed: "_Parsed") -> str:
-    """Derive the default output path ``<dataset-name>.statistics.json``.
+    """Derive the default output path ``<dataset-name>.statistics.zarr``.
 
     The name is the basename of the (first) dataset with any ``.zarr``/``.zip``
     extension stripped; for a JSON config the short label is used instead.
@@ -187,7 +191,7 @@ def _default_output(parsed: "_Parsed") -> str:
     for ext in (".zarr", ".zip"):
         if name.endswith(ext):
             name = name[: -len(ext)]
-    return f"{name}.statistics.json"
+    return f"{name}.statistics.zarr"
 
 
 def _parse(tokens: list[str]) -> _Parsed:
@@ -414,19 +418,64 @@ def _compare_block(
     return block
 
 
-def _jsonable(obj: Any) -> Any:
-    """Recursively convert numpy arrays/scalars to plain Python for JSON output."""
-    if isinstance(obj, np.ndarray):
-        return [None if (isinstance(x, float) and np.isnan(x)) else x for x in obj.tolist()]
-    if isinstance(obj, (np.floating, np.integer)):
-        return obj.item()
-    if isinstance(obj, dict):
-        return {k: _jsonable(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
-        return [_jsonable(v) for v in obj]
-    if isinstance(obj, float) and np.isnan(obj):
-        return None
-    return obj
+def _write_zarr(
+    output: str,
+    variables: list[str],
+    results: dict[str, Any],
+    tendency: str | None,
+    overwrite: bool,
+) -> None:
+    """Write statistics results to a minimal zarr store compatible with ``open_dataset``.
+
+    The store contains only the arrays needed for use as a ``statistics`` or
+    ``statistics_tendencies`` override in ``open_dataset``. It has no ``data``
+    array and no ``dates`` array, so it cannot be iterated; it exists only to
+    serve ``statistics`` and ``statistics_tendencies`` look-ups.
+
+    Parameters
+    ----------
+    output : str
+        Path for the zarr store directory.
+    variables : list of str
+        Variable names, in order.
+    results : dict
+        Engine results dict (keys ``statistics`` and ``tendency``).
+    tendency : str or None
+        The tendency delta string (e.g. ``"6h"``), used to derive the zarr key
+        names expected by ``GriddedZarr.statistics_tendencies``.
+    overwrite : bool
+        If ``True``, remove an existing store before writing.
+    """
+    from anemoi.utils.dates import frequency_to_string
+    from anemoi.utils.dates import frequency_to_timedelta
+
+    if overwrite and os.path.exists(output):
+        shutil.rmtree(output)
+
+    store = zarr.open_group(store=zarr.DirectoryStore(output), mode="w")
+    n = len(variables)
+
+    # Minimal attrs so that open_dataset recognises this as a gridded store.
+    store.attrs["layout"] = "gridded"
+    store.attrs["variables"] = list(variables)
+    store.attrs["missing_dates"] = []
+
+    # Dummy data array: zero time steps, correct variable count, 1 ensemble member,
+    # 1 grid point.  open_dataset needs this to exist but never reads values from it
+    # when the store is used solely as a statistics source.
+    store.create_dataset("data", shape=(0, n, 1, 1), dtype="float32")
+
+    if results["statistics"] is not None:
+        for key in STATISTICS:
+            store.create_dataset(key, data=results["statistics"][key].astype(np.float64))
+
+    if results["tendency"] is not None and tendency is not None:
+        delta_str = frequency_to_string(frequency_to_timedelta(tendency))
+        for key in STATISTICS:
+            zarr_key = f"statistics_tendencies_{delta_str}_{key}"
+            store.create_dataset(zarr_key, data=results["tendency"][key].astype(np.float64))
+        # Store the frequency so that statistics_tendencies(delta=None) works.
+        store.attrs["frequency"] = delta_str
 
 
 class Compute(Command):
@@ -453,11 +502,11 @@ class Compute(Command):
                 "<dataset> [key=value ...] [--statistics] [--statistics-tendencies 6h] "
                 "[--statistics-residual <dataset-2> [key=value ...]] [--chunk-size N] "
                 "[--sample-dates FRACTION] "
-                "[--compare] [--output FILE.json] [--overwrite] [--checkpoint PATH] [--resume] [--parallel N]. "
+                "[--compare] [--output FILE.zarr] [--overwrite] [--checkpoint PATH] [--resume] [--parallel N]. "
                 "<dataset> may be a name/path with key=value open_dataset options, or a single "
                 "JSON literal that is a complete open_dataset config (compute options stay as flags). "
-                "Results are written to <dataset-name>.statistics.json by default (use --output to change, "
-                "--overwrite to replace an existing file). NaNs are ignored by default."
+                "Results are written to <dataset-name>.statistics.zarr by default (use --output to change, "
+                "--overwrite to replace an existing store). NaNs are ignored by default."
             ),
         )
 
@@ -474,8 +523,10 @@ class Compute(Command):
         # Resolve the output path and fail fast (before any computation) if it
         # already exists and --overwrite was not given.
         output = parsed.output or _default_output(parsed)
+        if not output.endswith(".zarr"):
+            output += ".zarr"
         if os.path.exists(output) and not parsed.overwrite:
-            raise ValueError(f"Output file already exists: {output} (use --overwrite to replace it)")
+            raise ValueError(f"Output store already exists: {output} (use --overwrite to replace it)")
 
         sha = _args_sha(parsed)
         checkpoint = parsed.checkpoint or os.path.join(os.getcwd(), f"compute-checkpoint-{sha}.pkl")
@@ -502,17 +553,6 @@ class Compute(Command):
 
         variables, results = run_engine(task)
 
-        # Build a JSON-serialisable document while printing the tables.
-        document: dict[str, Any] = {
-            "dataset": parsed.label,
-            "residual": parsed.residual_label if parsed.has_residual else None,
-            "variables": variables,
-            "tendency": parsed.tendency,
-            "statistics": None,
-            "tendency_statistics": None,
-            "compare": {},
-        }
-
         stats_title = (
             f"Residual statistics ({parsed.label} - {parsed.residual_label})"
             if parsed.has_residual
@@ -521,7 +561,6 @@ class Compute(Command):
 
         if results["statistics"] is not None:
             _print_statistics(stats_title, variables, results["statistics"])
-            document["statistics"] = results["statistics"]
 
         if results["tendency"] is not None:
             t_title = (
@@ -530,18 +569,14 @@ class Compute(Command):
                 else f"Tendency statistics (delta={parsed.tendency})"
             )
             _print_statistics(t_title, variables, results["tendency"])
-            document["tendency_statistics"] = results["tendency"]
 
         if parsed.compare:
-            self._compare(parsed, variables, results, document)
+            self._compare(parsed, variables, results)
 
-        with open(output, "w") as f:
-            json.dump(_jsonable(document), f, indent=2)
+        _write_zarr(output, variables, results, parsed.tendency, parsed.overwrite)
         LOG.info("Results written to %s", output)
 
-    def _compare(
-        self, parsed: "_Parsed", variables: list[str], results: dict[str, Any], document: dict[str, Any]
-    ) -> None:
+    def _compare(self, parsed: "_Parsed", variables: list[str], results: dict[str, Any]) -> None:
         """Compare recomputed statistics with the dataset's stored statistics.
 
         Parameters
@@ -552,8 +587,6 @@ class Compute(Command):
             Variable names.
         results : dict
             The recomputed results from the engine.
-        document : dict
-            The output document to augment with the comparison.
         """
         if parsed.has_residual:
             LOG.warning("--compare is not meaningful for residuals (no stored stats); skipping.")
@@ -564,7 +597,7 @@ class Compute(Command):
         ds = open_dataset(*parsed.open_args, **parsed.open_kwargs)
 
         if results["statistics"] is not None:
-            document["compare"]["statistics"] = _compare_block(
+            _compare_block(
                 f"Compare statistics vs stored ({parsed.label})",
                 variables,
                 results["statistics"],
@@ -578,7 +611,7 @@ class Compute(Command):
             except Exception as e:  # noqa: BLE001 - dataset may not store this delta
                 LOG.warning("Could not read stored tendencies for delta=%s: %s", label, e)
                 return
-            document["compare"]["tendency"] = _compare_block(
+            _compare_block(
                 f"Compare tendency statistics vs stored (delta={label})",
                 variables,
                 results["tendency"],

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -92,19 +92,19 @@ def test_parse_json_rejects_keyvalue() -> None:
 
 
 def test_parse_residual_with_trailing_flags() -> None:
-    p = _parse([DS0, "--statistics-residual", DS1, "thinning=4", "--output", "x.json", "--parallel", "2"])
+    p = _parse([DS0, "--statistics-residual", DS1, "thinning=4", "--output", "x.zarr", "--parallel", "2"])
     assert p.has_residual is True
     assert p.residual_open_args == [DS1]
     assert p.residual_open_kwargs == {"thinning": 4}
-    assert p.output == "x.json"
+    assert p.output == "x.zarr"
     assert p.parallel == 2
 
 
 def test_parse_residual_json() -> None:
     cfg = json.dumps({"dataset": DS1, "grid": "o96"})
-    p = _parse([DS0, "--statistics-residual", cfg, "--output", "y.json"])
+    p = _parse([DS0, "--statistics-residual", cfg, "--output", "y.zarr"])
     assert p.residual_open_args == [{"dataset": DS1, "grid": "o96"}]
-    assert p.output == "y.json"
+    assert p.output == "y.zarr"
 
 
 def test_parse_old_flags_rejected() -> None:
@@ -281,34 +281,38 @@ def test_run_with_live_enabled_smoke() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Full command (CLI entry) with JSON output
+# Full command (CLI entry) with zarr output
 # --------------------------------------------------------------------------- #
 
 
 @mockup_open_zarr
-def test_command_writes_json(tmp_path, monkeypatch) -> None:
+def test_command_writes_zarr(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)  # keep the default checkpoint out of the repo
-    out = tmp_path / "out.json"
+    out = tmp_path / "out.zarr"
     Compute().run(argparse.Namespace(rest=[DS0, "--statistics", "--output", str(out)]))
-    doc = json.loads(out.read_text())
-    assert doc["dataset"] == DS0
-    assert doc["statistics"] is not None
-    assert len(doc["statistics"]["mean"]) == len(open_dataset(DS0).variables)
+    import zarr as _zarr
+
+    store = _zarr.open(str(out), mode="r")
+    assert list(store.attrs["variables"]) == list(open_dataset(DS0).variables)
+    assert "mean" in store
+    assert len(store["mean"]) == len(open_dataset(DS0).variables)
 
 
 def test_default_output_name() -> None:
-    assert _default_output(_parse(["/data/foo.zarr", "--statistics"])) == "foo.statistics.json"
-    assert _default_output(_parse(["bar", "--statistics"])) == "bar.statistics.json"
+    assert _default_output(_parse(["/data/foo.zarr", "--statistics"])) == "foo.statistics.zarr"
+    assert _default_output(_parse(["bar", "--statistics"])) == "bar.statistics.zarr"
 
 
 @mockup_open_zarr
 def test_default_output_and_overwrite(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
-    default = tmp_path / f"{DS0}.statistics.json"
+    default = tmp_path / f"{DS0}.statistics.zarr"
 
     Compute().run(argparse.Namespace(rest=[DS0, "--statistics"]))
     assert default.exists()
-    assert json.loads(default.read_text())["dataset"] == DS0
+    import zarr as _zarr
+
+    assert list(_zarr.open(str(default), mode="r").attrs["variables"]) == list(open_dataset(DS0).variables)
 
     # Re-running without --overwrite must fail before recomputing.
     with pytest.raises(ValueError, match="already exists"):
@@ -320,15 +324,17 @@ def test_default_output_and_overwrite(tmp_path, monkeypatch) -> None:
 
 
 @mockup_open_zarr
-def test_command_json_equals_name_form(tmp_path, monkeypatch) -> None:
+def test_command_npz_equals_name_form(tmp_path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
-    name_out = tmp_path / "name.json"
-    json_out = tmp_path / "json.json"
+    name_out = tmp_path / "name.zarr"
+    json_out = tmp_path / "json.zarr"
     Compute().run(argparse.Namespace(rest=[DS0, "--statistics", "--output", str(name_out)]))
     cfg = json.dumps({"dataset": DS0})
     Compute().run(argparse.Namespace(rest=[cfg, "--statistics", "--output", str(json_out)]))
-    a = json.loads(name_out.read_text())["statistics"]["mean"]
-    b = json.loads(json_out.read_text())["statistics"]["mean"]
+    import zarr as _zarr
+
+    a = _zarr.open(str(name_out), mode="r")["mean"][:]
+    b = _zarr.open(str(json_out), mode="r")["mean"][:]
     np.testing.assert_allclose(a, b)
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -290,8 +290,8 @@ def zarr_from_str(name: str, mode: str) -> zarr.Group:
         Zarr dataset.
     """
     # Format: test-2021-2021-6h-o96-abcd-0
-    if "/" in name:
-        return true_zarr_open(name)
+    if "/" in name or mode == "w":
+        return true_zarr_open(name, mode)
 
     name, _ = os.path.splitext(name)
 


### PR DESCRIPTION
## Description
Write outputs to a zarr store when recomputing statistics with `anemoi-datasets compute`

## What problem does this change solve?
We need to load residual statistics to train downscaling diffusion models. PR https://github.com/ecmwf/anemoi-datasets/pull/651 adds a command to compute residual statistics. PR https://github.com/ecmwf/anemoi-datasets/pull/633 allows to selectively overwrite tendencies statistics from a zarr store with residual statistics using `open_dataset(my_dataset, statistics_tendencies=residual_statistics.zarr)`. This requires a zarr store as input instead of a JSON which the compute command currently produces.

Edit: We also need the dates arrays to be able to access metadata of a dataset opened as described above. I am not sure if adding the dates array is the best approach. Alternatives would be to change how we overwrite statistics or how we access metadata; both of these seem to require more changes.

It is not clear to me whether other use cases need the JSON output. To overwrite statistics, tendencies statistics etc., zarr stores are required. If the intent is to compare statistics against recomputed statistics with `--compare`, then JSON might be the better choice. So we might want to enable both options.

## What issue or task does this change relate to?
Relates to point 5 of https://github.com/ecmwf/anemoi-core/issues/1274

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)


<!-- readthedocs-preview anemoi-datasets start -->
----
📚 Documentation preview 📚: https://anemoi-datasets--730.org.readthedocs.build/en/730/

<!-- readthedocs-preview anemoi-datasets end -->