### PR TITLE
perf(cutout): push the grid index down to the source datasets

### DIFF
--- a/src/anemoi/datasets/usage/gridded/grids.py
+++ b/src/anemoi/datasets/usage/gridded/grids.py
@@ -596,10 +596,19 @@ class Cutout(GridsBase):
             index = (index, slice(None), slice(None), slice(None))
         return self._get_tuple(index)
 
+    @cached_property
+    def _mask_indices(self) -> list[NDArray[Any]]:
+        """Source-space indices retained by each mask (LAMs first, then the global dataset)."""
+        return [np.flatnonzero(mask) for mask in self.masks] + [np.flatnonzero(self.global_mask)]
+
     @debug_indexing
     @expand_list_indexing
     def _get_tuple(self, index: TupleIndex) -> NDArray[Any]:
         """Helper method that applies masks and retrieves data from each dataset according to the specified index.
+
+        The grid index is pushed down to the underlying datasets, so only the
+        requested region is read (e.g. only the zarr chunks it intersects),
+        instead of loading full fields and slicing in memory.
 
         Parameters
         ----------
@@ -612,16 +621,21 @@ class Cutout(GridsBase):
             Concatenated data array from all datasets based on the index.
         """
         index, changes = index_to_slices(index, self.shape)
-        # Select data from each LAM
-        lam_data = [lam[index[:3]] for lam in self.lams]
+        slices = length_to_slices(index[self.axis], [len(kept) for kept in self._mask_indices])
 
-        # First apply spatial indexing on `self.globe` and then apply the mask
-        globe_data_sliced = self.globe[index[:3]]
-        globe_data = globe_data_sliced[..., self.global_mask]
+        parts = []
+        for dataset, kept, local in zip(self.datasets, self._mask_indices, slices):
+            if local is None:
+                continue
+            sel = kept[local]
+            window = slice(int(sel[0]), int(sel[-1]) + 1)
+            part = dataset[index[:3] + (window,)]
+            if len(sel) != window.stop - window.start:
+                # the mask has holes (or the slice a step) inside the window
+                part = part[..., sel - window.start]
+            parts.append(part)
 
-        # Concatenate LAM data with global data, apply the grid slicing
-        result = np.concatenate(lam_data + [globe_data], axis=self.axis)[..., index[3]]
-
+        result = np.concatenate(parts, axis=self.axis)
         return apply_index_to_slices_changes(result, changes)
 
     def collect_supporting_arrays(self, collected: list[Any], *path: Any) -> None:

--- a/src/anemoi/datasets/usage/gridded/grids.py
+++ b/src/anemoi/datasets/usage/gridded/grids.py
@@ -621,18 +621,27 @@ class Cutout(GridsBase):
             Concatenated data array from all datasets based on the index.
         """
         index, changes = index_to_slices(index, self.shape)
-        slices = length_to_slices(index[self.axis], [len(kept) for kept in self._mask_indices])
+        # resolve the requested grid index for each dataset
+        # relative to each dataset's own masked points
+        requested_per_dataset = length_to_slices(
+            index[self.axis], [len(source_indices) for source_indices in self._mask_indices]
+        )
 
         parts = []
-        for dataset, kept, local in zip(self.datasets, self._mask_indices, slices):
-            if local is None:
+        for dataset, source_indices, requested in zip(self.datasets, self._mask_indices, requested_per_dataset):
+            if requested is None:
+                # this dataset contributes no columns to the requested grid range
                 continue
-            sel = kept[local]
-            window = slice(int(sel[0]), int(sel[-1]) + 1)
+            # translate the requested positions from "retained points within a mask"
+            # back to native grid-point indices
+            selected_source_indices = source_indices[requested]
+            # read only the contiguous native-grid range spanning the selected points,
+            # instead of loading the whole grid and slicing in memory
+            window = slice(int(selected_source_indices[0]), int(selected_source_indices[-1]) + 1)
             part = dataset[index[:3] + (window,)]
-            if len(sel) != window.stop - window.start:
-                # the mask has holes (or the slice a step) inside the window
-                part = part[..., sel - window.start]
+            if len(selected_source_indices) != window.stop - window.start:
+                # the mask has gaps (or the index has a step) inside the window: drop the extra points
+                part = part[..., selected_source_indices - window.start]
             parts.append(part)
 
         result = np.concatenate(parts, axis=self.axis)

--- a/src/anemoi/datasets/usage/gridded/grids.py
+++ b/src/anemoi/datasets/usage/gridded/grids.py
@@ -621,6 +621,15 @@ class Cutout(GridsBase):
             Concatenated data array from all datasets based on the index.
         """
         index, changes = index_to_slices(index, self.shape)
+
+        reverse = index[self.axis].step < 0
+        if reverse:
+            # length_to_slices only handles ascending selections: read the
+            # same points in ascending order and flip the result back below
+            positions = range(*index[self.axis].indices(self.shape[self.axis]))
+            ascending = slice(positions[-1], positions[0] + 1, -positions.step) if positions else slice(0, 0)
+            index, _ = update_tuple(index, self.axis, ascending)
+
         # resolve the requested grid index for each dataset
         # relative to each dataset's own masked points
         requested_per_dataset = length_to_slices(
@@ -644,7 +653,15 @@ class Cutout(GridsBase):
                 part = part[..., selected_source_indices - window.start]
             parts.append(part)
 
-        result = np.concatenate(parts, axis=self.axis)
+        if parts:
+            result = np.concatenate(parts, axis=self.axis)
+        else:
+            # empty grid selection: no dataset was read, build the empty block directly
+            shape = tuple(len(range(*s.indices(n))) for s, n in zip(index, self.shape))
+            result = np.empty(shape, dtype=self.dtype)
+
+        if reverse:
+            result = np.flip(result, axis=self.axis)
         return apply_index_to_slices_changes(result, changes)
 
     def collect_supporting_arrays(self, collected: list[Any], *path: Any) -> None:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1762,6 +1762,54 @@ def test_cutout_masks_version_mismatch_warns(tmp_path, caplog):
     assert any("0.0.0-bogus" in r.message for r in caplog.records)
 
 
+def test_cutout_get_tuple_pushes_grid_index_down():
+    class _ArrayDataset:
+        def __init__(self, data):
+            self.data = data
+            self.shape = data.shape
+            self.grid_requests = []
+
+        def __getitem__(self, index):
+            self.grid_requests.append(index[3])
+            return self.data[index]
+
+    rng = np.random.default_rng(0)
+    lams = [_ArrayDataset(rng.random((5, 3, 1, n), dtype="float32")) for n in (10, 8)]
+    globe = _ArrayDataset(rng.random((5, 3, 1, 12), dtype="float32"))
+
+    obj = object.__new__(Cutout)
+    obj.axis = 3
+    obj.lams = lams
+    obj.globe = globe
+    obj.datasets = [*lams, globe]
+    obj.masks = [np.tile([True, False], 5), np.tile([True, True, False, True], 2)]
+    obj.global_mask = np.tile([False, True, True], 4)
+
+    # Reference semantics: mask each dataset, concatenate, then index.
+    masks = [*obj.masks, obj.global_mask]
+    reference = np.concatenate([d.data[..., m] for d, m in zip(obj.datasets, masks)], axis=3)
+    assert obj.shape == reference.shape  # kept points: 5 + 6 + 8
+
+    indices = [
+        (slice(None), slice(None), slice(None), slice(None)),
+        (slice(1, 3), slice(0, 2), slice(None), slice(2, 14)),  # straddles all three datasets
+        (slice(None), slice(None), slice(None), slice(0, 17, 3)),
+        ([0, 2], slice(None), slice(None), slice(4, 9)),
+        (slice(2, 3), slice(None), slice(None), slice(18, 19)),
+    ]
+    for index in indices:
+        np.testing.assert_array_equal(obj[index], reference[index])
+
+    # The grid index reaches the sources: a request inside the first LAM asks it
+    # for the bounding window of the kept points only, and never touches the rest.
+    for d in obj.datasets:
+        d.grid_requests.clear()
+    obj[slice(None), slice(None), slice(None), slice(1, 4)]
+    assert lams[0].grid_requests == [slice(2, 7)]
+    assert lams[1].grid_requests == []
+    assert globe.grid_requests == []
+
+
 def test_cutout_masks_save_is_atomic_on_error(tmp_path, monkeypatch):
     masks_path = tmp_path / "masks.npz"
     obj = _make_cutout()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1770,6 +1770,7 @@ def pushdown_cutout():
         def __init__(self, data):
             self.data = data
             self.shape = data.shape
+            self.dtype = data.dtype
             self.grid_requests = []
 
         def __getitem__(self, index):
@@ -1785,6 +1786,7 @@ def pushdown_cutout():
     obj.lams = lams
     obj.globe = globe
     obj.datasets = [*lams, globe]
+    obj.forward = lams[0]  # Combined forwards dtype & co to the first dataset
     obj.masks = [np.tile([True, False], 5), np.tile([True, True, False, True], 2)]
     obj.global_mask = np.tile([False, True, True], 4)
 
@@ -1823,8 +1825,32 @@ def pushdown_cutout():
             (slice(None), slice(None), slice(None), slice(1, 4)),
             [[slice(2, 7)], [], []],
         ),
+        (
+            # descending selections are read ascending and flipped back
+            (slice(None), slice(None), slice(None), slice(14, 2, -1)),
+            [[slice(6, 9)], [slice(0, 8)], [slice(1, 6)]],
+        ),
+        (
+            (slice(None), slice(None), slice(None), slice(16, 4, -3)),
+            [[], [slice(3, 8)], [slice(4, 9)]],
+        ),
+        (
+            # empty selections read nothing and return an empty block
+            (slice(None), slice(None), slice(None), slice(5, 5)),
+            [[], [], []],
+        ),
     ],
-    ids=["full", "straddles-all-three", "stepped", "list-dates", "global-only", "inside-first-lam"],
+    ids=[
+        "full",
+        "straddles-all-three",
+        "stepped",
+        "list-dates",
+        "global-only",
+        "inside-first-lam",
+        "descending",
+        "descending-stepped",
+        "empty",
+    ],
 )
 def test_cutout_get_tuple_pushes_grid_index_down(pushdown_cutout, index, expected_grid_requests):
     obj, reference = pushdown_cutout

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1762,8 +1762,11 @@ def test_cutout_masks_version_mismatch_warns(tmp_path, caplog):
     assert any("0.0.0-bogus" in r.message for r in caplog.records)
 
 
-def test_cutout_get_tuple_pushes_grid_index_down():
+@pytest.fixture(scope="module")
+def pushdown_cutout():
     class _ArrayDataset:
+        # Records the grid index of every access, so the test can check which
+        # dataset was asked for which grid window (and which were never read).
         def __init__(self, data):
             self.data = data
             self.shape = data.shape
@@ -1789,25 +1792,51 @@ def test_cutout_get_tuple_pushes_grid_index_down():
     masks = [*obj.masks, obj.global_mask]
     reference = np.concatenate([d.data[..., m] for d, m in zip(obj.datasets, masks)], axis=3)
     assert obj.shape == reference.shape  # kept points: 5 + 6 + 8
+    return obj, reference
 
-    indices = [
-        (slice(None), slice(None), slice(None), slice(None)),
-        (slice(1, 3), slice(0, 2), slice(None), slice(2, 14)),  # straddles all three datasets
-        (slice(None), slice(None), slice(None), slice(0, 17, 3)),
-        ([0, 2], slice(None), slice(None), slice(4, 9)),
-        (slice(2, 3), slice(None), slice(None), slice(18, 19)),
-    ]
-    for index in indices:
-        np.testing.assert_array_equal(obj[index], reference[index])
 
-    # The grid index reaches the sources: a request inside the first LAM asks it
-    # for the bounding window of the kept points only, and never touches the rest.
+@pytest.mark.parametrize(
+    "index,expected_grid_requests",
+    [
+        (
+            (slice(None), slice(None), slice(None), slice(None)),
+            [[slice(0, 9)], [slice(0, 8)], [slice(1, 12)]],
+        ),
+        (
+            (slice(1, 3), slice(0, 2), slice(None), slice(2, 14)),
+            [[slice(4, 9)], [slice(0, 8)], [slice(1, 5)]],
+        ),
+        (
+            (slice(None), slice(None), slice(None), slice(0, 17, 3)),
+            [[slice(0, 7)], [slice(1, 6)], [slice(2, 8)]],
+        ),
+        (
+            # the list index expands to one read per date
+            ([0, 2], slice(None), slice(None), slice(4, 9)),
+            [[slice(8, 9)] * 2, [slice(0, 5)] * 2, []],
+        ),
+        (
+            (slice(2, 3), slice(None), slice(None), slice(18, 19)),
+            [[], [], [slice(11, 12)]],
+        ),
+        (
+            (slice(None), slice(None), slice(None), slice(1, 4)),
+            [[slice(2, 7)], [], []],
+        ),
+    ],
+    ids=["full", "straddles-all-three", "stepped", "list-dates", "global-only", "inside-first-lam"],
+)
+def test_cutout_get_tuple_pushes_grid_index_down(pushdown_cutout, index, expected_grid_requests):
+    obj, reference = pushdown_cutout
     for d in obj.datasets:
         d.grid_requests.clear()
-    obj[slice(None), slice(None), slice(None), slice(1, 4)]
-    assert lams[0].grid_requests == [slice(2, 7)]
-    assert lams[1].grid_requests == []
-    assert globe.grid_requests == []
+
+    np.testing.assert_array_equal(obj[index], reference[index])
+
+    # The grid index reaches the sources: each dataset is asked only for the
+    # bounding window of its kept points inside the requested range, and
+    # datasets outside that range are never touched.
+    assert [d.grid_requests for d in obj.datasets] == expected_grid_requests
 
 
 def test_cutout_masks_save_is_atomic_on_error(tmp_path, monkeypatch):


### PR DESCRIPTION
## Description

`Cutout.__getitem__` loaded the full grid from every source dataset and applied the requested grid index in memory, so a grid-subset request (e.g. a reader rank fetching its shard in model-sharded training) still read and decompressed every chunk of every source. This change pushes the grid index down to the sources, the same way `GivenAxis._get_tuple` already does for `grids`: the request is split across the masked sources with `length_to_slices`, each source is asked only for the bounding window of its selected points, and in-memory re-indexing happens only where the mask has holes inside that window. For a single-LAM cutout the LAM request reduces to a pure slice, so only the intersecting chunks are read. Results are byte-identical.

## What problem does this change solve?

Performance: makes spatial chunking effective under `cutout`, so model-sharded training reads only each rank's grid shard instead of the full field. Full-grid reads and all other access patterns are unchanged.

## What issue or task does this change relate to?

—

## Additional notes ##

Tested in a parallel setting on a 1 km stretched-grid configuration (2 nodes, 4 GPUs per model, each reader rank requesting its grid shard): per-step training losses are identical to main, a rank's shard read is 5x faster, training throughput is 1.6x higher (data loading no longer stalls the steps), and dataloader-worker memory is reduced by 50%. The new unit test covers a hierarchical two-LAM cutout with holed masks: equality with the mask-then-concatenate reference across index patterns, and sources are never asked for more than the bounding window.

One known limitation, to be addressed separately: reads are chunk-granular, and shard boundaries generally do not coincide with chunk boundaries, so a rank may still decompress more than it needs when the store has few spatial chunks. Mitigations (finer spatial chunking at dataset build time, or chunk-aligned shard sizes on the training side) are outside the scope of this PR.

This change was developed in tandem with AI coding agents.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
