### PR TITLE
fix: resolve _compare_arrays logic bug

### DIFF
--- a/src/anemoi/datasets/commands/compare.py
+++ b/src/anemoi/datasets/commands/compare.py
@@ -146,7 +146,7 @@ def _compare_arrays(errors, a: zarr.Array, b: zarr.Array, path: str, tolerance=1
     # Divide by two because both arrays need to be in memory
     half_memory = max_memory // 2
     itemsize = a.dtype.itemsize
-    chunk_size = math.prod(a.chunks) * itemsize  # Prefered buffer size if fits in memory
+    chunk_size = math.prod(a.chunks) * itemsize  # Preferred buffer size if fits in memory
     buffer_size = chunk_size if chunk_size < half_memory else half_memory
 
     # The first (chunk) axis is often 1, so subdivide also other dimensions as needed

--- a/src/anemoi/datasets/commands/compare.py
+++ b/src/anemoi/datasets/commands/compare.py
@@ -173,9 +173,7 @@ def _compare_arrays(errors, a: zarr.Array, b: zarr.Array, path: str, tolerance=1
         tasks = []
         starts = itertools.product(*(range(0, s, step) for s, step in zip(a.shape, buffer_shape)))
         for start in tqdm.tqdm(list(starts), desc=f"Comparing {path}"):
-            slice_obj = tuple(
-                slice(i, min(i + step, s)) for i, step, s in zip(start, buffer_shape, a.shape)
-            )
+            slice_obj = tuple(slice(i, min(i + step, s)) for i, step, s in zip(start, buffer_shape, a.shape))
             tasks.append(
                 executor.submit(_compare_arrays_partial, errors, a, b, slice_obj, path, tolerance, close_ok=close_ok)
             )

--- a/src/anemoi/datasets/commands/compare.py
+++ b/src/anemoi/datasets/commands/compare.py
@@ -8,7 +8,9 @@
 # nor does it submit to any jurisdiction.
 
 
+import itertools
 import logging
+import math
 import os
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
@@ -25,6 +27,8 @@ from anemoi.datasets.usage.store import open_zarr_store
 from . import Command
 
 LOG = logging.getLogger(__name__)
+
+MAX_MEMORY_PER_WORKER = 2 * 1024 * 1024 * 1024  # 2 GB per CPU core
 
 
 class _Error:
@@ -105,7 +109,7 @@ class ErrorCollector:
 
 
 def _compare_arrays_partial(
-    errors, a: zarr.Array, b: zarr.Array, slice_obj: slice, path: str, tolerance=1e-6, close_ok=False
+    errors, a: zarr.Array, b: zarr.Array, slice_obj: tuple, path: str, tolerance=1e-6, close_ok=False
 ) -> None:
     """Compare two arrays."""
     a = a[slice_obj]
@@ -136,27 +140,45 @@ def _compare_arrays(errors, a: zarr.Array, b: zarr.Array, path: str, tolerance=1
         errors.error(f"🧮 {path}: dtypes are different {a.dtype} != {b.dtype}")
         return
 
-    buffer_size = 64 * 1024 * 1024  # 64 MB
-
-    size = a.dtype.itemsize * a.size
-    row_size = a.dtype.itemsize * a.shape[0]
-    if size <= buffer_size:
-        return _compare_arrays_partial(errors, a, b, slice(None), path, tolerance, close_ok=close_ok)
-
     max_workers = os.cpu_count() or 4
-    max_memory = 1024 * 1024 * 1024  # 2 GB
+    max_memory = MAX_MEMORY_PER_WORKER
+
     # Divide by two because both arrays need to be in memory
-    max_workers = max(min(max_workers, max_memory // buffer_size // 2), 1)
+    half_memory = max_memory // 2
+    itemsize = a.dtype.itemsize
+    chunk_size = math.prod(a.chunks) * itemsize  # Prefered buffer size if fits in memory
+    buffer_size = chunk_size if chunk_size < half_memory else half_memory
+
+    # The first (chunk) axis is often 1, so subdivide also other dimensions as needed
+    # to bring the buffer shape down to buffer_size.
+    buffer_shape = list(a.chunks)
+    while math.prod(buffer_shape) * itemsize > buffer_size:
+        i = max(range(len(buffer_shape)), key=lambda i: buffer_shape[i])
+        if buffer_shape[i] == 1:
+            break
+        buffer_shape[i] = max(1, buffer_shape[i] // 2)
+    buffer_shape = tuple(buffer_shape)
+    buffer_size = math.prod(buffer_shape) * itemsize
+
+    max_workers = max(min(max_workers, (half_memory * max_workers) // buffer_size), 1)
+
+    size = itemsize * a.size
+    if size <= buffer_size:
+        return _compare_arrays_partial(errors, a, b, (slice(None),), path, tolerance, close_ok=close_ok)
 
     LOG.info(f"Comparing large arrays {path} using {max_workers} workers")
 
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
 
         tasks = []
-        step = max(1, buffer_size // row_size)
-        for i in tqdm.tqdm(range(0, a.shape[0], step), desc=f"Comparing {path}"):
-            last = min(i + step, a.shape[0])
-            tasks.append(executor.submit(_compare_arrays_partial, errors, a, b, slice(i, last), path, tolerance))
+        starts = itertools.product(*(range(0, s, step) for s, step in zip(a.shape, buffer_shape)))
+        for start in tqdm.tqdm(list(starts), desc=f"Comparing {path}"):
+            slice_obj = tuple(
+                slice(i, min(i + step, s)) for i, step, s in zip(start, buffer_shape, a.shape)
+            )
+            tasks.append(
+                executor.submit(_compare_arrays_partial, errors, a, b, slice_obj, path, tolerance, close_ok=close_ok)
+            )
 
         with tqdm.tqdm(total=len(tasks), desc=f"Comparing {path}", unit="part") as pbar:
             for future in as_completed(tasks):

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -60,7 +60,8 @@ def test_compare_detects_different_values(datasets) -> None:
 def test_compare_with_small_buffer_subdivides_non_leading_dimensions(datasets, monkeypatch) -> None:
     """Force a tiny memory budget so the buffer shape must be subdivided along
     dimensions other than the (size 1) leading one, exercising the multi-axis
-    task splitting logic."""
+    task splitting logic.
+    """
     reference, actual, _ = datasets
 
     monkeypatch.setattr(compare_module, "MAX_MEMORY_PER_WORKER", 256)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,75 @@
+# (C) Copyright 2024-2026 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import os
+
+import numpy as np
+import pytest
+import zarr
+
+from anemoi.datasets.commands import compare as compare_module
+from anemoi.datasets.commands.compare import compare_anemoi_datasets
+
+
+def _make_store(path: str, data: np.ndarray, chunks: tuple) -> None:
+    """Create a minimal zarr store with a single "data" array."""
+    group = zarr.open_group(path, mode="w")
+    group.create_dataset("data", data=data, chunks=chunks, dtype=data.dtype)
+
+
+@pytest.fixture
+def datasets(tmp_path):
+    data = np.arange(24 * 4 * 5, dtype=np.float64).reshape(24, 4, 5)
+
+    reference = os.path.join(tmp_path, "reference.zarr")
+    actual = os.path.join(tmp_path, "actual.zarr")
+
+    # Chunked with a leading dimension of size 1, as is common for anemoi datasets
+    _make_store(reference, data, chunks=(1, 4, 5))
+    _make_store(actual, data.copy(), chunks=(1, 4, 5))
+
+    return reference, actual, data
+
+
+def test_compare_identical_datasets(datasets) -> None:
+    reference, actual, _ = datasets
+
+    errors = compare_anemoi_datasets(reference, actual, data=True)
+
+    assert not errors
+
+
+def test_compare_detects_different_values(datasets) -> None:
+    reference, actual, data = datasets
+
+    group = zarr.open_group(actual, mode="a")
+    group["data"][10, 2, 3] = data[10, 2, 3] + 1000.0
+
+    errors = compare_anemoi_datasets(reference, actual, data=True)
+
+    assert errors
+    assert any("different" in repr(e) for e in errors._errors)
+
+
+def test_compare_with_small_buffer_subdivides_non_leading_dimensions(datasets, monkeypatch) -> None:
+    """Force a tiny memory budget so the buffer shape must be subdivided along
+    dimensions other than the (size 1) leading one, exercising the multi-axis
+    task splitting logic."""
+    reference, actual, _ = datasets
+
+    monkeypatch.setattr(compare_module, "MAX_MEMORY_PER_WORKER", 256)
+
+    errors = compare_anemoi_datasets(reference, actual, data=True)
+    assert not errors
+
+    group = zarr.open_group(actual, mode="a")
+    group["data"][5, 1, 2] += 1.0
+
+    errors = compare_anemoi_datasets(reference, actual, data=True)
+    assert errors


### PR DESCRIPTION
## Description
`_compare_arrays` refactoring 

## What problem does this change solve?
This PR resolves the wrong logic behind data loading in `_compare_arrays` function leading to OOM.
Specifically:
* The buffer size is changed from 64MB to chunk size if it fits in memory for efficiency purpose (chunk only read once).
* The data array is subdivided along all the necessary dimensions so that the subarrays loaded by each thread fits in buffer size.
* The max memory is defined per CPU core to fix the definition of the number of threads.
* Some integration tests are added.

## What issue or task does this change relate to?
#746


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
