### PR TITLE
fix: mismatch between shape and missing dates

### DIFF
--- a/src/anemoi/datasets/create/creator.py
+++ b/src/anemoi/datasets/create/creator.py
@@ -33,7 +33,7 @@ from .parts import PartFilter
 
 LOG = logging.getLogger(__name__)
 
-VERSION = "0.20"
+VERSION = "0.21"
 
 LOG = logging.getLogger(__name__)
 

--- a/src/anemoi/datasets/create/creator.py
+++ b/src/anemoi/datasets/create/creator.py
@@ -264,6 +264,7 @@ class Creator(ABC):
         self.finalise_dataset(dataset)
         self.final_metadata(dataset)
         dataset.touch()
+        self.task_verify()
 
     def task_finalise_prepare(self) -> None:
         LOG.info("Finalising dataset (prepare stage).")
@@ -290,6 +291,7 @@ class Creator(ABC):
         self.finalise_tidy(dataset)
         self.final_metadata(dataset)
         dataset.touch()
+        self.task_verify()
 
     @abstractmethod
     def finalise_dataset(self, dataset: Dataset) -> None:
@@ -361,8 +363,9 @@ class Creator(ABC):
 
     ########################
     def task_verify(self) -> None:
-        LOG.info("BACK: Verifying dataset.")
-        return
+        from anemoi.datasets.validation import dataset_validation
+
+        dataset_validation(self.path, raise_error=True)
 
     ########################
     def task_statistics(self) -> None:

--- a/src/anemoi/datasets/create/gridded/creator.py
+++ b/src/anemoi/datasets/create/gridded/creator.py
@@ -351,13 +351,13 @@ class SimpleGriddedCreator(GriddedCreator):
         return SimpleGriddedContext(self.recipe)
 
     def initialise_dataset(self, dataset: Dataset) -> None:
-        dates = self.groups.provider.values
-        shape = (len(dates),) + self.minimal_input.shape[1:]
+        all_dates = self.groups.provider.full_dates_list()
+        shape = (len(all_dates),) + self.minimal_input.shape[1:]
 
         assert len(shape) == 4, f"Expected 4D shape, got {shape}"
 
         coords = self.minimal_input.coords
-        coords["dates"] = dates
+        coords["dates"] = all_dates
         chunks = self.recipe.output.get_chunking(coords)
 
         grid_points = self.minimal_input.grid_points
@@ -373,6 +373,6 @@ class SimpleGriddedCreator(GriddedCreator):
             fill_value=np.nan,
         )
 
-        dataset.add_array(name="dates", data=np.array(dates, "<M8[s]"), dimensions=("time",))
+        dataset.add_array(name="dates", data=np.array(all_dates, "<M8[s]"), dimensions=("time",))
         dataset.add_array(name="latitudes", data=grid_points[0], dimensions=("cell",))
         dataset.add_array(name="longitudes", data=grid_points[1], dimensions=("cell",))

--- a/src/anemoi/datasets/create/gridded/creator.py
+++ b/src/anemoi/datasets/create/gridded/creator.py
@@ -42,7 +42,7 @@ class GriddedCreator(Creator):
         Trajectories override this to return the base dates (factorised from
         ``(basetime, step)`` tuples).
         """
-        return self.groups.provider.values
+        return self.groups.provider.full_dates_list()
 
     def _metadata_date_range(self):
         """Return ``(start_date, end_date)`` for the dataset metadata.

--- a/src/anemoi/datasets/create/recipe/dates.py
+++ b/src/anemoi/datasets/create/recipe/dates.py
@@ -117,6 +117,9 @@ class DatesProvider(BaseModel):
         """
         return len(self.values)
 
+    def full_dates_list(self) -> list[datetime.datetime]:
+        raise NotImplementedError(f"{self.__class__.__name__} does not implement full_dates_list()")
+
 
 class StartEndDates(DatesProvider):
 
@@ -313,6 +316,9 @@ class TrajectoryDates(DatesProvider):
 
 class ValuesDates(DatesProvider):
     values: list[datetime.datetime]
+
+    def full_dates_list(self) -> list[datetime.datetime]:
+        return list(self.values)
 
 
 class HindcastsDates(DatesProvider):

--- a/src/anemoi/datasets/create/recipe/dates.py
+++ b/src/anemoi/datasets/create/recipe/dates.py
@@ -169,6 +169,15 @@ class StartEndDates(DatesProvider):
     def dump(self, dumper):
         return dumper.start_end_dates(self.start, self.end, self.frequency)
 
+    def full_dates_list(self) -> list[datetime.datetime]:
+        """Return the list of dates including missing ones."""
+        dates = []
+        date = self.start
+        while date <= self.end:
+            dates.append(date)
+            date += self.frequency
+        return dates
+
 
 class BaseDates(StartEndDates):
     """Basetimes (forecast initialisation times) for the ``trajectories`` layout.

--- a/src/anemoi/datasets/create/statistics.py
+++ b/src/anemoi/datasets/create/statistics.py
@@ -401,6 +401,13 @@ class _ConstantsCollector(_Base):
 
         data = data[:, self._index]
 
+        if data.ndim > 1:
+            missing_rows = np.isnan(data).reshape(data.shape[0], -1).all(axis=1)
+            if missing_rows.any():
+                data = data[~missing_rows]
+                if len(data) == 0:
+                    return
+
         if self._first is None:
             self._first = data[0].copy()
             self._nans = np.isnan(self._first)

--- a/src/anemoi/datasets/usage/gridded/store.py
+++ b/src/anemoi/datasets/usage/gridded/store.py
@@ -370,21 +370,36 @@ class ZarrWithMissingDates(GriddedZarr):
 
 
 class ReIndex:
-    def __init__(self, data, index_mapping):
+    def __init__(self, data, shape, index_mapping):
         self.data = data
+        self.shape = shape
         self.index_mapping = index_mapping
 
     def __getitem__(self, idx):
-        if isinstance(idx, int):
-            return self.data[self.index_mapping[idx]]
+        match idx:
+            case int():
+                return self.data[self.index_mapping[idx]]
 
-        if isinstance(idx, slice):
-            return self.data[[self.index_mapping[i] for i in range(*idx.indices(len(self.data)))]]
+            case slice():
+                return self.data[[self.index_mapping[i] for i in range(*idx.indices(len(self.data)))]]
 
-        if isinstance(idx, (list, tuple)):
-            return self.data[[self.index_mapping[i] for i in idx]]
+            case list():
+                return self.data[[self.index_mapping[i] for i in idx]]
 
-        raise TypeError(f"Unsupported index type: {type(idx)}")
+            case tuple():
+                first, *rest = idx
+                match first:
+                    case int():
+                        return self.data[self.index_mapping[first], *rest]
+
+                    case slice():
+                        return self.data[[self.index_mapping[i] for i in range(*first.indices(len(self.data)))], *rest]
+
+                    case list():
+                        return self.data[[self.index_mapping[i] for i in first], *rest]
+
+            case _:
+                raise TypeError(f"Unsupported index type: {type(idx)}")
 
 
 class ZarrWithMissingDatesFix(ZarrWithMissingDates):
@@ -418,9 +433,9 @@ class ZarrWithMissingDatesFix(ZarrWithMissingDates):
 
         self._actual_dates = np.array(actual_dates)
 
-        self.data = ReIndex(store["data"], index_mapping)
-
         super().__init__(store, path)
+
+        self.data = ReIndex(store["data"], self.shape, index_mapping)
 
     def mutate(self):
         return self
@@ -433,3 +448,11 @@ class ZarrWithMissingDatesFix(ZarrWithMissingDates):
     def label(self) -> str:
         """Return the label of the dataset."""
         return "zarr?"
+
+    @property
+    def shape(self):
+        s = super().shape
+        return (len(self._actual_dates), *s[1:])
+
+    def __len__(self):
+        return len(self._actual_dates)

--- a/src/anemoi/datasets/usage/gridded/store.py
+++ b/src/anemoi/datasets/usage/gridded/store.py
@@ -222,7 +222,8 @@ class GriddedZarr(ZarrStore):
 
         if len(self.store.attrs.get("missing_dates", [])):
             LOG.warning(f"Dataset {self} has missing dates")
-            return ZarrWithMissingDates(self.store, self.path)
+            return ZarrWithMissingDates(self.store, self.path).mutate()
+
         return self
 
     def tree(self) -> Node:
@@ -289,14 +290,32 @@ class ZarrWithMissingDates(GriddedZarr):
         self.missing_to_dates = {i: d for i, d in enumerate(self.dates) if d in missing_dates}
         self._missing = set(self.missing_to_dates)
 
+    def mutate(self) -> "ZarrWithMissingDates":
+        start, end, frequency = self.start_date, self.end_date, self.frequency
+        size = self.data.shape[0]
+        expected_size = ((end - start) // frequency) + 1
+
+        if size == expected_size:
+            return self
+
+        from anemoi.datasets import __version__ as anemoi_version
+
+        LOG.warning("=" * 80)
+        LOG.warning(
+            "!!!!! This datasets was created by a version of anemoi-datasets that encoded missing dates incorrectly."
+        )
+        LOG.warning(
+            f"Please consider recreating this dataset with a newer version of anemoi-datasets (e.g. {anemoi_version} )"
+        )
+        LOG.warning("=" * 80)
+        LOG.warning("Applying in memory fix...")
+        LOG.warning("=" * 80)
+        return ZarrWithMissingDatesFix(self.store, self.path)
+
     @property
     def missing(self) -> set[int]:
         """Return the missing dates of the dataset."""
         return self._missing
-
-    def mutate(self) -> Dataset:
-        """Mutate the dataset."""
-        return self
 
     @debug_indexing
     @expand_list_indexing
@@ -349,7 +368,68 @@ class ZarrWithMissingDates(GriddedZarr):
         """Return the label of the dataset."""
         return "zarr*"
 
-    # def origin(self, index):
-    #     if index[0] in self.missing:
-    #         self._report_missing(index[0])
-    #     return super().origin(index)
+
+class ReIndex:
+    def __init__(self, data, index_mapping):
+        self.data = data
+        self.index_mapping = index_mapping
+
+    def __getitem__(self, idx):
+        if isinstance(idx, int):
+            return self.data[self.index_mapping[idx]]
+
+        if isinstance(idx, slice):
+            return self.data[[self.index_mapping[i] for i in range(*idx.indices(len(self.data)))]]
+
+        if isinstance(idx, (list, tuple)):
+            return self.data[[self.index_mapping[i] for i in idx]]
+
+        raise TypeError(f"Unsupported index type: {type(idx)}")
+
+
+class ZarrWithMissingDatesFix(ZarrWithMissingDates):
+    """A zarr dataset with missing dates. Fix missing entries."""
+
+    def __init__(self, store: zarr.Group, path: str) -> None:
+
+        # First fix the dates
+
+        stored_dates = store["dates"][:]
+
+        start = stored_dates[0]
+        end = stored_dates[-1]
+        frequency = frequency_to_timedelta(store.attrs["frequency"])
+
+        missing_dates = store.attrs.get("missing_dates", [])
+        missing_dates = {np.datetime64(x, "s") for x in missing_dates}
+
+        actual_dates = []
+        date = start
+        i = 0
+        index_mapping = {}
+        while date <= end:
+            npdate = np.datetime64(date, "s")
+            if npdate not in missing_dates:
+                index_mapping[i] = len(index_mapping)
+            i += 1
+
+            actual_dates.append(npdate)
+            date += frequency
+
+        self._actual_dates = np.array(actual_dates)
+
+        self.data = ReIndex(store["data"], index_mapping)
+
+        super().__init__(store, path)
+
+    def mutate(self):
+        return self
+
+    @property
+    def dates(self):
+        return self._actual_dates
+
+    @property
+    def label(self) -> str:
+        """Return the label of the dataset."""
+        return "zarr?"

--- a/src/anemoi/datasets/usage/gridded/store.py
+++ b/src/anemoi/datasets/usage/gridded/store.py
@@ -381,10 +381,11 @@ class ReIndex:
                 return self.data[self.index_mapping[idx]]
 
             case slice():
-                return self.data[[self.index_mapping[i] for i in range(*idx.indices(len(self.data)))]]
+                indices = range(*idx.indices(len(self.data)))
+                return np.stack([self.data[self.index_mapping[i]] for i in indices])
 
             case list():
-                return self.data[[self.index_mapping[i] for i in idx]]
+                return np.stack([self.data[self.index_mapping[i]] for i in idx])
 
             case tuple():
                 first, *rest = idx
@@ -393,10 +394,11 @@ class ReIndex:
                         return self.data[self.index_mapping[first], *rest]
 
                     case slice():
-                        return self.data[[self.index_mapping[i] for i in range(*first.indices(len(self.data)))], *rest]
+                        indices = range(*first.indices(len(self.data)))
+                        return np.stack([self.data[self.index_mapping[i], *rest] for i in indices])
 
                     case list():
-                        return self.data[[self.index_mapping[i] for i in first], *rest]
+                        return np.stack([self.data[self.index_mapping[i], *rest] for i in first])
 
             case _:
                 raise TypeError(f"Unsupported index type: {type(idx)}")

--- a/src/anemoi/datasets/usage/gridded/store.py
+++ b/src/anemoi/datasets/usage/gridded/store.py
@@ -310,7 +310,12 @@ class ZarrWithMissingDates(GriddedZarr):
         LOG.warning("=" * 80)
         LOG.warning("Applying in memory fix...")
         LOG.warning("=" * 80)
-        return ZarrWithMissingDatesFix(self.store, self.path)
+        use_fix = int(os.environ.get("ANEMOI_DATASETS_MISSING_DATES_FIX_EXPERIMENTAL", 0))
+        if use_fix:
+            return ZarrWithMissingDatesFix(self.store, self.path)
+        raise ValueError(
+            f"Dataset {self} is not encoded correctly. Please recreate the dataset with a newer version of anemoi-datasets."
+        )
 
     @property
     def missing(self) -> set[int]:

--- a/src/anemoi/datasets/usage/gridded/store.py
+++ b/src/anemoi/datasets/usage/gridded/store.py
@@ -371,17 +371,19 @@ class ZarrWithMissingDates(GriddedZarr):
 
 class ReIndex:
     def __init__(self, data, shape, index_mapping):
+        self._len = shape[0]
         self.data = data
         self.shape = shape
         self.index_mapping = index_mapping
 
     def __getitem__(self, idx):
+
         match idx:
             case int():
                 return self.data[self.index_mapping[idx]]
 
             case slice():
-                indices = range(*idx.indices(len(self.data)))
+                indices = list(range(*idx.indices(self._len)))
                 return np.stack([self.data[self.index_mapping[i]] for i in indices])
 
             case list():
@@ -394,7 +396,7 @@ class ReIndex:
                         return self.data[self.index_mapping[first], *rest]
 
                     case slice():
-                        indices = range(*first.indices(len(self.data)))
+                        indices = list(range(*first.indices(self._len)))
                         return np.stack([self.data[self.index_mapping[i], *rest] for i in indices])
 
                     case list():

--- a/src/anemoi/datasets/usage/store.py
+++ b/src/anemoi/datasets/usage/store.py
@@ -280,6 +280,11 @@ class ZarrStore(Dataset):
         )
 
     @property
+    def layout(self) -> str | None:
+        """Return the layout of the dataset."""
+        return self.store.attrs.get("layout", "gridded")
+
+    @property
     def resolution(self) -> str | None:
         """Return the resolution of the dataset."""
         return self.store.attrs.get("resolution")

--- a/src/anemoi/datasets/validation.py
+++ b/src/anemoi/datasets/validation.py
@@ -1,0 +1,92 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+import logging
+from abc import ABC
+from abc import abstractmethod
+
+from anemoi.datasets import open_dataset
+
+LOG = logging.getLogger(__name__)
+
+
+class Validator(ABC):
+
+    @abstractmethod
+    def validate(self, path, ds, errors): ...
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+
+class UnknownValidator(Validator):
+    def validate(self, path, ds, errors):
+        errors.append(f"Unknown layout: {ds.layout}")
+
+
+class GriddedValidator(Validator):
+    def validate(self, path, ds, errors):
+        # Check shape againts dates
+        start, end, frequency = ds.start_date, ds.end_date, ds.frequency
+        size = ds.data.shape[0]
+        expected_size = ((end - start) // frequency) + 1
+        if size != expected_size:
+            errors.append(
+                f"Gridded dataset size {size} does not match expected size {expected_size} based on dates (missing={len(ds.missing)})."
+            )
+
+
+class TabularValidator(Validator):
+    def validate(self, path, ds, errors):
+        LOG.warning(f"Tabular layout validation is not fully implemented for dataset at path: {path}")
+
+
+class TrajectoriesValidator(Validator):
+    def validate(self, path, ds, errors):
+        LOG.warning(f"Trajectories layout validation is not fully implemented for dataset at path: {path}")
+
+
+VALIDATORS = {
+    "gridded": GriddedValidator(),
+    "tabular": TabularValidator(),
+    "trajectories": TrajectoriesValidator(),
+}
+
+
+def dataset_validation(path, raise_error=False):
+    ds = open_dataset(path)
+
+    validator = VALIDATORS.get(ds.layout, UnknownValidator)
+
+    errors = []
+    validator.validate(path, ds, errors)
+    for error in errors:
+        LOG.error(f"{validator}: {error}")
+
+    if errors:
+        if raise_error:
+            raise ValueError(f"Validation errors for dataset at path {path}: {errors}")
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python validation.py <dataset_path>")
+        sys.exit(1)
+    dataset_path = sys.argv[1]
+    try:
+        dataset_validation(dataset_path)
+        print(f"Dataset at path {dataset_path} is valid.")
+    except ValueError as e:
+        print(e)
+        sys.exit(1)

--- a/tests/create/test_missing_range.py
+++ b/tests/create/test_missing_range.py
@@ -42,12 +42,14 @@ def test_missing_range_dates_are_supported(tmp_path: Path, load_source: LoadSour
 
     assert dates.tolist() == [
         np.datetime64("2020-12-30T00:00:00"),
+        np.datetime64("2020-12-30T12:00:00"),
         np.datetime64("2020-12-31T00:00:00"),
         np.datetime64("2020-12-31T12:00:00"),
         np.datetime64("2021-01-01T00:00:00"),
         np.datetime64("2021-01-01T12:00:00"),
         np.datetime64("2021-01-02T00:00:00"),
         np.datetime64("2021-01-02T12:00:00"),
+        np.datetime64("2021-01-03T00:00:00"),
         np.datetime64("2021-01-03T12:00:00"),
     ]
 
@@ -67,11 +69,13 @@ def test_missing_mixture_dates_are_supported(tmp_path: Path, load_source: LoadSo
 
     assert dates.tolist() == [
         np.datetime64("2020-12-30T00:00:00"),
+        np.datetime64("2020-12-30T12:00:00"),
         np.datetime64("2020-12-31T00:00:00"),
         np.datetime64("2020-12-31T12:00:00"),
         np.datetime64("2021-01-01T00:00:00"),
         np.datetime64("2021-01-01T12:00:00"),
         np.datetime64("2021-01-02T00:00:00"),
         np.datetime64("2021-01-02T12:00:00"),
+        np.datetime64("2021-01-03T00:00:00"),
         np.datetime64("2021-01-03T12:00:00"),
     ]


### PR DESCRIPTION
We found a bug impacting datasets with missing dates. The bug was introduced in version 0.5.37 (version 0.5.36 was correct).

This bug: https://github.com/ecmwf/anemoi-datasets/issues/700,  has actually nothing to do with cutout. This is a bug in the handling of missing dates at creation time, which means that the datasets created are incorrect: the data in zarr is compressed, i.e. we skip the missing dates, and all as the result the dataset is shorter. This bug was introduced version 0.5.37
 
This fix that bugs. In addition, open_dataset will fail on badly encoded datasets.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
