### PR TITLE
feature: optional specification of dates when using multiple netcdf files as source with paterns

### DIFF
--- a/src/anemoi/datasets/create/sources/netcdf.py
+++ b/src/anemoi/datasets/create/sources/netcdf.py
@@ -42,4 +42,5 @@ class NetCDFSource(LegacySource):
         object
             The loaded data.
         """
-        return load_many("📁", context, dates, path, *args, **kwargs)
+
+        return load_many("📁", context, dates, path, date_content=kwargs.pop("date_content", None), *args, **kwargs)

--- a/src/anemoi/datasets/create/sources/patterns.py
+++ b/src/anemoi/datasets/create/sources/patterns.py
@@ -13,6 +13,7 @@ from collections.abc import Generator
 from typing import Any
 
 from earthkit.data.utils.patterns import Pattern
+from anemoi.datasets.dates import DatesProvider
 
 
 def _expand(paths: list[str]) -> Generator[str, None, None]:
@@ -52,7 +53,7 @@ def _expand(paths: list[str]) -> Generator[str, None, None]:
 
 
 def iterate_patterns(
-    path: str, dates: list[datetime.datetime], **kwargs: Any
+    path: str, dates: list[datetime.datetime], date_content:dict=None, **kwargs: Any
 ) -> Generator[tuple[str, list[str]], None, None]:
     """Iterate over patterns and expand them with given dates and additional keyword arguments.
 
@@ -73,10 +74,26 @@ def iterate_patterns(
     given_paths = path if isinstance(path, list) else [path]
 
     dates = [d.isoformat() for d in dates]
+    substitution_dates = {}
     if len(dates) > 0:
-        kwargs["date"] = dates
+        substitution_dates["date"] = dates
 
     for path in given_paths:
-        paths = Pattern(path).substitute(allow_extra=True, **kwargs)
-        for path in _expand(paths):
-            yield path, dates
+        paths = Pattern(path).substitute(allow_extra=True, **substitution_dates)
+        if date_content is not None:
+            start = Pattern(date_content["start"]).substitute(allow_extra=True, **substitution_dates)
+            end = Pattern(date_content["end"]).substitute(allow_extra=True, **substitution_dates)
+            frequency = date_content["frequency"]
+            substituted_dates = [
+                [
+                    d.isoformat() for d in DatesProvider.from_config(
+                **{"start": s, "end": e, "frequency":frequency})
+                ] for s, e in zip(start, end)
+                ]
+
+            for path, substituted_date in zip(_expand(paths), substituted_dates):
+                substituted_date = list(set(dates).intersection(substituted_date))
+                yield path, substituted_date
+        else:
+            for path in _expand(paths):
+                yield path, dates

--- a/src/anemoi/datasets/create/sources/patterns.py
+++ b/src/anemoi/datasets/create/sources/patterns.py
@@ -13,6 +13,7 @@ from collections.abc import Generator
 from typing import Any
 
 from earthkit.data.utils.patterns import Pattern
+
 from anemoi.datasets.dates import DatesProvider
 
 
@@ -53,7 +54,7 @@ def _expand(paths: list[str]) -> Generator[str, None, None]:
 
 
 def iterate_patterns(
-    path: str, dates: list[datetime.datetime], date_content:dict=None, **kwargs: Any
+    path: str, dates: list[datetime.datetime], date_content: dict = None, **kwargs: Any
 ) -> Generator[tuple[str, list[str]], None, None]:
     """Iterate over patterns and expand them with given dates and additional keyword arguments.
 
@@ -85,11 +86,9 @@ def iterate_patterns(
             end = Pattern(date_content["end"]).substitute(allow_extra=True, **substitution_dates)
             frequency = date_content["frequency"]
             substituted_dates = [
-                [
-                    d.isoformat() for d in DatesProvider.from_config(
-                **{"start": s, "end": e, "frequency":frequency})
-                ] for s, e in zip(start, end)
-                ]
+                [d.isoformat() for d in DatesProvider.from_config(**{"start": s, "end": e, "frequency": frequency})]
+                for s, e in zip(start, end)
+            ]
 
             for path, substituted_date in zip(_expand(paths), substituted_dates):
                 substituted_date = list(set(dates).intersection(substituted_date))

--- a/src/anemoi/datasets/create/sources/xarray_support/__init__.py
+++ b/src/anemoi/datasets/create/sources/xarray_support/__init__.py
@@ -136,7 +136,9 @@ def load_one(
     return result
 
 
-def load_many(emoji: str, context: Any, dates: list[datetime.datetime], pattern: str, date_content:dict=None, **kwargs: Any) -> ekd.FieldList:
+def load_many(
+    emoji: str, context: Any, dates: list[datetime.datetime], pattern: str, date_content: dict = None, **kwargs: Any
+) -> ekd.FieldList:
     """Loads multiple datasets.
 
     Parameters

--- a/src/anemoi/datasets/create/sources/xarray_support/__init__.py
+++ b/src/anemoi/datasets/create/sources/xarray_support/__init__.py
@@ -136,7 +136,7 @@ def load_one(
     return result
 
 
-def load_many(emoji: str, context: Any, dates: list[datetime.datetime], pattern: str, **kwargs: Any) -> ekd.FieldList:
+def load_many(emoji: str, context: Any, dates: list[datetime.datetime], pattern: str, date_content:dict=None, **kwargs: Any) -> ekd.FieldList:
     """Loads multiple datasets.
 
     Parameters
@@ -159,7 +159,7 @@ def load_many(emoji: str, context: Any, dates: list[datetime.datetime], pattern:
     """
     result = []
 
-    for path, dates in iterate_patterns(pattern, dates, **kwargs):
+    for path, dates in iterate_patterns(pattern, dates, date_content, **kwargs):
         result.append(load_one(emoji, context, dates, path, **kwargs))
 
     return MultiFieldList(result)


### PR DESCRIPTION
## Description
anemoi-datasets currently offers the possibility to use multiple netcdf as a source: https://anemoi.readthedocs.io/projects/datasets/en/latest/building/sources/netcdf.html#netcdf
I propose to incorporate a recipe option to specify with patterns which dates can be found in netcdf files, like this:

```yaml
dates:
  start: 2020-01-01 00:00:00
  end: 2020-12-31 23:59:59
  frequency: 3h
input:
  netcdf:
    path: /path/to/my/file_{date:strftime(%Y-%m-%d)}.nc
    date_content:
      start: "{date:strftime(%Y-%m-%d)}T00:00:00"
      end: "{date:strftime(%Y-%m-%d)}T23:59:59"
      frequency: 3h
```  
This recipe says that each file contains only a day's worth of dates. In turn, anemoi-dataset should only look for those specified dates in the files.

## What problem does this change solve?
I'm interested in reading several netcdf at once, which can be currently done with this:
```yaml
dates:
  start: 2020-01-01 00:00:00
  end: 2020-12-31 23:59:59
  frequency: 3h
input:
  netcdf:
    path: /path/to/my/file_{date:strftime(%Y-%m-%d)}.nc
```  
This is compatible with my netcdf files of daily 3h data for a year (366 files for year 2020), that are saved under a format like `file_2020_01_05.nc`.

While anemoi-datasets manages to compile and create the dataset, it is quite inefficient and throws many warnings:
```
2026-09-09 15:34:28 WARNING Could not find valid_datetime=2020-01-02T18:00:00 in TimeCoordinate[name=time,values=8,shape=(8,)] (alias of time)
```
This is because anemoi-datasets checks for the presence of each dataset date in each netcdf file, and returns a warning for each missing date (so (366-1)*366*8=1068720 warning lines in my case).

## What issue or task does this change relate to?
None

##  Additional notes ##
At the moment, I have only implemented a solution for netcdfs, though I guess it would work well for xarrays, or actually any source. 
In effect, the proposed change would allow to build anemoi datasets with netcdfs while having a similar file layout as gribs: https://anemoi.readthedocs.io/projects/datasets/en/latest/building/sources/grib.html#grib
I am quite bad at naming things, so I'd appreciate any proposition to make the optional recipe parameters better, and the code clearer.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
